### PR TITLE
feat(web): add frontend dashboard foundation + project setup

### DIFF
--- a/docs/plans/2026-03-11-frontend-dashboard-design.md
+++ b/docs/plans/2026-03-11-frontend-dashboard-design.md
@@ -1,0 +1,110 @@
+# Frontend Dashboard — Foundation + Project Setup
+
+## Design Document
+
+**Date:** 2026-03-11
+**Status:** Approved
+**Scope:** Foundation infrastructure (Tailwind, shadcn/ui, API client, layout) + Project Setup screen
+
+---
+
+## Decisions
+
+- **Scope:** Foundation + one screen (Project Setup). Other screens follow in later PRs.
+- **Auth:** Stubbed with hardcoded user ID. Clerk integration deferred.
+- **Theme:** Dark theme as default via CSS variables.
+- **Data fetching:** React Query (TanStack Query) only. Zustand deferred until multi-screen UI state is needed.
+- **Approach:** Page-first — Project Setup as simple page flow, not a wizard.
+
+---
+
+## 1. Foundation Infrastructure
+
+### Tailwind + shadcn/ui
+- Tailwind CSS 3.x with PostCSS and `tailwind.config.ts`
+- Dark theme default via CSS variables in `globals.css`
+- shadcn/ui initialized, components in `components/ui/`
+- Initial components: Button, Input, Label, Card, Textarea, Select, Badge, Separator
+
+### API Client Layer
+- `lib/api/client.ts` — fetch wrapper with base URL from `NEXT_PUBLIC_API_URL`, JSON headers, error handling
+- `lib/api/projects.ts` — typed functions for project CRUD
+- `lib/api/game-profiles.ts` — typed functions for game profile CRUD
+- `lib/types/` — TypeScript interfaces matching backend Pydantic schemas
+
+### React Query
+- QueryClientProvider wrapping app in layout.tsx
+- Custom hooks in `lib/hooks/` for projects and game profiles
+
+### Layout Shell
+- Collapsible dark sidebar (left) with nav items: Projects, Creative Library (disabled), Settings (disabled)
+- Top area: "Magnet" branding + placeholder user avatar
+- Main content area to the right
+- Responsive: sidebar collapses to icons on small screens
+
+### Routing
+```
+/                       → redirect to /projects
+/projects               → projects list
+/projects/new           → create project form
+/projects/[id]          → project detail + game profile form
+```
+
+---
+
+## 2. Project Setup Screen
+
+### /projects — Projects List
+- Card grid showing project name, status badge, created date
+- "New Project" button → /projects/new
+- Paginated via React Query
+
+### /projects/new — Create Project
+- Form with project name field + "Create Project" button
+- On submit: POST /api/projects with stubbed user_id
+- On success: redirect to /projects/[id]
+
+### /projects/[id] — Project Detail + Game Profile
+- Header: project name + status badge
+- Game Profile form fields:
+  - Genre (text input)
+  - Target Audience (text input)
+  - Core Mechanics (tag-style multi-input)
+  - Art Style (text input)
+  - Brand Guidelines (textarea)
+  - Competitors (tag-style multi-input)
+  - Key Selling Points (tag-style multi-input)
+- "Save Profile" → POST (create) or PATCH (update)
+- Success feedback on save
+- "Generate Concepts" button (disabled, coming soon)
+
+### Error Handling
+- Form validation on required fields
+- API error display (toast or inline)
+- Loading states via React Query isPending/isError
+
+---
+
+## 3. Testing Strategy
+
+- API client functions: unit tests with mocked fetch
+- React components: component tests with React Testing Library
+- React Query hooks: hook tests
+- Existing WebSocket hook tests remain unchanged
+
+---
+
+## 4. Backend Endpoints Consumed
+
+```
+POST   /api/projects                         → create project
+GET    /api/projects?user_id=...             → list projects
+GET    /api/projects/{id}                    → get project
+PATCH  /api/projects/{id}                    → update project
+DELETE /api/projects/{id}                    → delete project
+POST   /api/projects/{id}/game-profile       → create game profile
+GET    /api/projects/{id}/game-profile       → get game profile
+PATCH  /api/projects/{id}/game-profile       → update game profile
+```
+
+All endpoints return JSON with Pydantic-validated schemas. Pagination via offset/limit query params.

--- a/docs/plans/active/2026-03-11-frontend-dashboard.md
+++ b/docs/plans/active/2026-03-11-frontend-dashboard.md
@@ -25,7 +25,10 @@
 
 ## Decision Log
 
-- (populated during implementation)
+- Used getBaseUrl() function instead of top-level const for testability (Step 4)
+- Installed tailwindcss v3 (not v4) for PostCSS compatibility (Step 1)
+- Added @radix-ui/react-slot for Button asChild prop (Step 2)
+- Excluded vitest.config.ts from tsconfig.json to fix vite type conflict during build
 
 ---
 

--- a/docs/plans/active/2026-03-11-frontend-dashboard.md
+++ b/docs/plans/active/2026-03-11-frontend-dashboard.md
@@ -1,0 +1,293 @@
+# Frontend Dashboard — Foundation + Project Setup
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Set up the frontend foundation (Tailwind, shadcn/ui, API client, layout shell) and build the Project Setup screen with CRUD operations.
+
+**Architecture:** Next.js 14 App Router with React Query for server state. Thin fetch-based API client talks to the FastAPI backend. Dark-themed UI via Tailwind + shadcn/ui. Stubbed auth with hardcoded user ID.
+
+**Tech Stack:** Next.js 14, TypeScript, Tailwind CSS 3, shadcn/ui, TanStack React Query, vitest
+
+---
+
+## Context and Orientation
+
+- **Conventions:** TypeScript files use `kebab-case.ts(x)`. Components use `PascalCase`. Imports use `@/` alias. See `docs/conventions/naming.md` and `docs/conventions/import-ordering.md`.
+- **Existing code:** `lib/useBriefProgress.ts` and `lib/types/progress.ts` exist — don't break them. Tests in `__tests__/unit/`.
+- **Backend schemas:** `packages/api/app/schemas/project.py` defines `ProjectCreate`, `ProjectRead`, `ProjectUpdate`, `GameProfileCreateBody`, `GameProfileRead`, `GameProfileUpdate`.
+- **Enforcement:** Files must stay under 300 lines. No unused imports.
+- **Test commands:** `cd packages/web && npx vitest run`
+- **Lint commands:** `cd packages/web && npx eslint .`
+
+## Open Questions
+
+- None — all decisions made during brainstorming.
+
+## Decision Log
+
+- (populated during implementation)
+
+---
+
+## Steps
+
+### Step 1: Install Tailwind CSS and configure dark theme
+
+**What to do:** Install Tailwind CSS 3 with PostCSS and autoprefixer. Create config files. Set up `globals.css` with dark theme CSS variables matching shadcn/ui conventions. Update `layout.tsx` to import globals.css and apply the dark class.
+
+**Files:**
+- Create: `packages/web/tailwind.config.ts`
+- Create: `packages/web/postcss.config.js`
+- Create: `packages/web/app/globals.css`
+- Modify: `packages/web/app/layout.tsx`
+- Modify: `packages/web/package.json` (new deps)
+
+**Tests:** No unit tests — verified by build.
+
+**Verify:** `cd packages/web && npm run build`
+
+---
+
+### Step 2: Initialize shadcn/ui and install base components
+
+**What to do:** Initialize shadcn/ui with the `new-york` style and dark theme. Install components: button, input, label, card, textarea, badge, separator. These go into `components/ui/`.
+
+**Files:**
+- Create: `packages/web/components.json` (shadcn config)
+- Create: `packages/web/lib/utils.ts` (cn helper)
+- Create: `packages/web/components/ui/button.tsx`
+- Create: `packages/web/components/ui/input.tsx`
+- Create: `packages/web/components/ui/label.tsx`
+- Create: `packages/web/components/ui/card.tsx`
+- Create: `packages/web/components/ui/textarea.tsx`
+- Create: `packages/web/components/ui/badge.tsx`
+- Create: `packages/web/components/ui/separator.tsx`
+
+**Tests:** No unit tests — these are vendored components.
+
+**Verify:** `cd packages/web && npm run build`
+
+---
+
+### Step 3: Create TypeScript types matching backend schemas
+
+**What to do:** Create TypeScript interfaces that mirror the backend Pydantic schemas for Project and GameProfile. These are the API contract types.
+
+**Files:**
+- Create: `packages/web/lib/types/project.ts`
+- Create: `packages/web/lib/types/game-profile.ts`
+
+**Tests:** No unit tests — type-only files verified by build.
+
+**Verify:** `cd packages/web && npx tsc --noEmit`
+
+Types to create:
+
+```typescript
+// lib/types/project.ts
+export interface Project {
+  id: string;
+  user_id: string;
+  name: string;
+  status: string;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface ProjectCreate {
+  name: string;
+  user_id: string;
+}
+
+export interface ProjectUpdate {
+  name?: string;
+  status?: string;
+}
+```
+
+```typescript
+// lib/types/game-profile.ts
+export interface GameProfile {
+  id: string;
+  project_id: string;
+  genre: string | null;
+  target_audience: string | null;
+  core_mechanics: string[] | null;
+  art_style: string | null;
+  brand_guidelines: Record<string, unknown> | null;
+  competitors: string[] | null;
+  key_selling_points: string[] | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface GameProfileCreate {
+  genre?: string | null;
+  target_audience?: string | null;
+  core_mechanics?: string[] | null;
+  art_style?: string | null;
+  brand_guidelines?: Record<string, unknown> | null;
+  competitors?: string[] | null;
+  key_selling_points?: string[] | null;
+}
+
+export type GameProfileUpdate = GameProfileCreate;
+```
+
+---
+
+### Step 4: Build API client with fetch wrapper
+
+**What to do:** Create a thin fetch wrapper (`api-client.ts`) that handles base URL, JSON headers, and error responses. Then create typed functions for projects and game-profiles. Write tests first.
+
+**Files:**
+- Create: `packages/web/lib/api/client.ts`
+- Create: `packages/web/lib/api/projects.ts`
+- Create: `packages/web/lib/api/game-profiles.ts`
+- Test: `packages/web/__tests__/unit/api-client.test.ts`
+- Test: `packages/web/__tests__/unit/api-projects.test.ts`
+
+**Tests:**
+- `api-client.test.ts`: test that `apiGet`/`apiPost`/`apiPatch`/`apiDelete` call fetch with correct URL, headers, and handle error responses
+- `api-projects.test.ts`: test `createProject`, `listProjects`, `getProject` call the client correctly
+
+**Verify:** `cd packages/web && npx vitest run`
+
+API client shape:
+
+```typescript
+// lib/api/client.ts
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+  }
+}
+
+export async function apiGet<T>(path: string): Promise<T> { ... }
+export async function apiPost<T>(path: string, body: unknown): Promise<T> { ... }
+export async function apiPatch<T>(path: string, body: unknown): Promise<T> { ... }
+export async function apiDelete(path: string): Promise<void> { ... }
+```
+
+```typescript
+// lib/api/projects.ts
+export async function createProject(data: ProjectCreate): Promise<Project> { ... }
+export async function listProjects(userId: string, offset?: number, limit?: number): Promise<Project[]> { ... }
+export async function getProject(id: string): Promise<Project> { ... }
+export async function updateProject(id: string, data: ProjectUpdate): Promise<Project> { ... }
+export async function deleteProject(id: string): Promise<void> { ... }
+```
+
+```typescript
+// lib/api/game-profiles.ts
+export async function createGameProfile(projectId: string, data: GameProfileCreate): Promise<GameProfile> { ... }
+export async function getGameProfile(projectId: string): Promise<GameProfile> { ... }
+export async function updateGameProfile(projectId: string, data: GameProfileUpdate): Promise<GameProfile> { ... }
+```
+
+---
+
+### Step 5: Set up React Query provider and project hooks
+
+**What to do:** Install `@tanstack/react-query`. Create a client-component provider wrapper. Create custom hooks for project and game-profile queries/mutations. Write tests.
+
+**Files:**
+- Modify: `packages/web/package.json` (add @tanstack/react-query)
+- Create: `packages/web/components/providers.tsx`
+- Modify: `packages/web/app/layout.tsx` (wrap with Providers)
+- Create: `packages/web/lib/hooks/use-projects.ts`
+- Create: `packages/web/lib/hooks/use-game-profile.ts`
+- Test: `packages/web/__tests__/unit/use-projects.test.tsx`
+
+**Tests:**
+- `use-projects.test.tsx`: test `useProjects` returns data from listProjects, test `useCreateProject` calls createProject and invalidates query
+
+**Verify:** `cd packages/web && npx vitest run`
+
+Hook shapes:
+
+```typescript
+// lib/hooks/use-projects.ts
+export function useProjects(userId: string) { ... }       // useQuery
+export function useProject(id: string) { ... }             // useQuery
+export function useCreateProject() { ... }                 // useMutation
+export function useUpdateProject(id: string) { ... }       // useMutation
+export function useDeleteProject() { ... }                 // useMutation
+```
+
+```typescript
+// lib/hooks/use-game-profile.ts
+export function useGameProfile(projectId: string) { ... }          // useQuery
+export function useCreateGameProfile(projectId: string) { ... }    // useMutation
+export function useUpdateGameProfile(projectId: string) { ... }    // useMutation
+```
+
+---
+
+### Step 6: Build layout shell with sidebar navigation
+
+**What to do:** Create the app shell with a dark sidebar, nav items, and main content area. The sidebar has "Magnet" branding at top, navigation links (Projects active, others disabled), and a stubbed user avatar at bottom. Use shadcn/ui components. Write a component test.
+
+**Files:**
+- Create: `packages/web/components/sidebar.tsx`
+- Create: `packages/web/components/app-shell.tsx`
+- Modify: `packages/web/app/layout.tsx` (use AppShell)
+- Test: `packages/web/__tests__/unit/sidebar.test.tsx`
+
+**Tests:**
+- `sidebar.test.tsx`: test that sidebar renders "Magnet" branding, renders "Projects" nav link, renders disabled "Creative Library" item
+
+**Verify:** `cd packages/web && npx vitest run && npm run build`
+
+---
+
+### Step 7: Build projects list page
+
+**What to do:** Create the `/projects` page showing project cards with name, status badge, and created date. Include a "New Project" button linking to `/projects/new`. Use the `useProjects` hook. Also redirect `/` to `/projects`. Write component test.
+
+**Files:**
+- Modify: `packages/web/app/page.tsx` (redirect to /projects)
+- Create: `packages/web/app/projects/page.tsx`
+- Create: `packages/web/components/project-card.tsx`
+- Test: `packages/web/__tests__/unit/project-card.test.tsx`
+
+**Tests:**
+- `project-card.test.tsx`: test that card renders project name, status badge, and formatted date
+
+**Verify:** `cd packages/web && npx vitest run && npm run build`
+
+---
+
+### Step 8: Build create project page
+
+**What to do:** Create `/projects/new` with a form containing project name input and "Create Project" button. On submit, call `useCreateProject` with a hardcoded `user_id` stub. On success, redirect to `/projects/[id]`. Write component test.
+
+**Files:**
+- Create: `packages/web/app/projects/new/page.tsx`
+- Create: `packages/web/components/create-project-form.tsx`
+- Create: `packages/web/lib/constants.ts` (STUB_USER_ID)
+- Test: `packages/web/__tests__/unit/create-project-form.test.tsx`
+
+**Tests:**
+- `create-project-form.test.tsx`: test that form renders name input and submit button, test that submit calls createProject with correct data
+
+**Verify:** `cd packages/web && npx vitest run && npm run build`
+
+---
+
+### Step 9: Build project detail page with game profile form
+
+**What to do:** Create `/projects/[id]` page showing project header (name + status badge) and game profile form. The form has fields for genre, target audience, core mechanics (comma-separated input), art style, brand guidelines (textarea), competitors (comma-separated), key selling points (comma-separated). Save button creates or updates the profile. Write component test.
+
+**Files:**
+- Create: `packages/web/app/projects/[id]/page.tsx`
+- Create: `packages/web/components/game-profile-form.tsx`
+- Create: `packages/web/components/tag-input.tsx` (reusable comma-separated → array input)
+- Test: `packages/web/__tests__/unit/game-profile-form.test.tsx`
+
+**Tests:**
+- `game-profile-form.test.tsx`: test that form renders all fields, test that submit calls createGameProfile with correct payload
+
+**Verify:** `cd packages/web && npx vitest run && npm run build`

--- a/packages/web/__tests__/setup.ts
+++ b/packages/web/__tests__/setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/web/__tests__/unit/api-client.test.ts
+++ b/packages/web/__tests__/unit/api-client.test.ts
@@ -28,6 +28,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("apiGet", () => {
@@ -46,11 +47,9 @@ describe("apiGet", () => {
     const fetchMock = mockFetchError(404, "Not Found");
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(apiGet("/api/projects/999")).rejects.toThrow(ApiError);
-    await expect(apiGet("/api/projects/999")).rejects.toMatchObject({
-      status: 404,
-      message: "Not Found",
-    });
+    const error = await apiGet("/api/projects/999").catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ status: 404, message: "Not Found" });
   });
 });
 
@@ -75,11 +74,9 @@ describe("apiPost", () => {
     const fetchMock = mockFetchError(422, "Validation Error");
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(apiPost("/api/projects", {})).rejects.toThrow(ApiError);
-    await expect(apiPost("/api/projects", {})).rejects.toMatchObject({
-      status: 422,
-      message: "Validation Error",
-    });
+    const error = await apiPost("/api/projects", {}).catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ status: 422, message: "Validation Error" });
   });
 });
 
@@ -104,11 +101,9 @@ describe("apiPatch", () => {
     const fetchMock = mockFetchError(500, "Internal Server Error");
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(apiPatch("/api/projects/1", {})).rejects.toThrow(ApiError);
-    await expect(apiPatch("/api/projects/1", {})).rejects.toMatchObject({
-      status: 500,
-      message: "Internal Server Error",
-    });
+    const error = await apiPatch("/api/projects/1", {}).catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ status: 500, message: "Internal Server Error" });
   });
 });
 
@@ -128,10 +123,8 @@ describe("apiDelete", () => {
     const fetchMock = mockFetchError(403, "Forbidden");
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(apiDelete("/api/projects/1")).rejects.toThrow(ApiError);
-    await expect(apiDelete("/api/projects/1")).rejects.toMatchObject({
-      status: 403,
-      message: "Forbidden",
-    });
+    const error = await apiDelete("/api/projects/1").catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ status: 403, message: "Forbidden" });
   });
 });

--- a/packages/web/__tests__/unit/api-client.test.ts
+++ b/packages/web/__tests__/unit/api-client.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { apiGet, apiPost, apiPatch, apiDelete, ApiError } from "@/lib/api/client";
+
+const TEST_API_URL = "http://test-api:9000";
+
+function mockFetchOk(data: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(""),
+  });
+}
+
+function mockFetchError(status: number, body: string) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve(null),
+    text: () => Promise.resolve(body),
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("process", {
+    env: { NEXT_PUBLIC_API_URL: TEST_API_URL },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("apiGet", () => {
+  it("calls fetch with correct URL and returns parsed JSON", async () => {
+    const data = { id: "1", name: "Test" };
+    const fetchMock = mockFetchOk(data);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiGet("/api/projects");
+
+    expect(fetchMock).toHaveBeenCalledWith(`${TEST_API_URL}/api/projects`);
+    expect(result).toEqual(data);
+  });
+
+  it("throws ApiError with status and message on non-ok response", async () => {
+    const fetchMock = mockFetchError(404, "Not Found");
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiGet("/api/projects/999")).rejects.toThrow(ApiError);
+    await expect(apiGet("/api/projects/999")).rejects.toMatchObject({
+      status: 404,
+      message: "Not Found",
+    });
+  });
+});
+
+describe("apiPost", () => {
+  it("calls fetch with POST method, JSON headers, and stringified body", async () => {
+    const responseData = { id: "1", name: "New" };
+    const requestBody = { name: "New" };
+    const fetchMock = mockFetchOk(responseData);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiPost("/api/projects", requestBody);
+
+    expect(fetchMock).toHaveBeenCalledWith(`${TEST_API_URL}/api/projects`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(requestBody),
+    });
+    expect(result).toEqual(responseData);
+  });
+
+  it("throws ApiError on non-ok response", async () => {
+    const fetchMock = mockFetchError(422, "Validation Error");
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiPost("/api/projects", {})).rejects.toThrow(ApiError);
+    await expect(apiPost("/api/projects", {})).rejects.toMatchObject({
+      status: 422,
+      message: "Validation Error",
+    });
+  });
+});
+
+describe("apiPatch", () => {
+  it("calls fetch with PATCH method, JSON headers, and stringified body", async () => {
+    const responseData = { id: "1", name: "Updated" };
+    const requestBody = { name: "Updated" };
+    const fetchMock = mockFetchOk(responseData);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiPatch("/api/projects/1", requestBody);
+
+    expect(fetchMock).toHaveBeenCalledWith(`${TEST_API_URL}/api/projects/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(requestBody),
+    });
+    expect(result).toEqual(responseData);
+  });
+
+  it("throws ApiError on non-ok response", async () => {
+    const fetchMock = mockFetchError(500, "Internal Server Error");
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiPatch("/api/projects/1", {})).rejects.toThrow(ApiError);
+    await expect(apiPatch("/api/projects/1", {})).rejects.toMatchObject({
+      status: 500,
+      message: "Internal Server Error",
+    });
+  });
+});
+
+describe("apiDelete", () => {
+  it("calls fetch with DELETE method", async () => {
+    const fetchMock = mockFetchOk(undefined);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiDelete("/api/projects/1");
+
+    expect(fetchMock).toHaveBeenCalledWith(`${TEST_API_URL}/api/projects/1`, {
+      method: "DELETE",
+    });
+  });
+
+  it("throws ApiError on non-ok response", async () => {
+    const fetchMock = mockFetchError(403, "Forbidden");
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiDelete("/api/projects/1")).rejects.toThrow(ApiError);
+    await expect(apiDelete("/api/projects/1")).rejects.toMatchObject({
+      status: 403,
+      message: "Forbidden",
+    });
+  });
+});

--- a/packages/web/__tests__/unit/api-projects.test.ts
+++ b/packages/web/__tests__/unit/api-projects.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Project } from "@/lib/types/project";
+
+// Mock the client module before importing projects
+vi.mock("@/lib/api/client", () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+  apiPatch: vi.fn(),
+  apiDelete: vi.fn(),
+}));
+
+import { apiGet, apiPost, apiPatch, apiDelete } from "@/lib/api/client";
+import {
+  createProject,
+  listProjects,
+  getProject,
+  updateProject,
+  deleteProject,
+} from "@/lib/api/projects";
+
+const mockProject: Project = {
+  id: "proj-1",
+  user_id: "user-1",
+  name: "Test Project",
+  status: "active",
+  created_at: "2026-03-11T00:00:00Z",
+  updated_at: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createProject", () => {
+  it("calls apiPost with /api/projects and body", async () => {
+    vi.mocked(apiPost).mockResolvedValue(mockProject);
+
+    const body = { name: "Test Project", user_id: "user-1" };
+    const result = await createProject(body);
+
+    expect(apiPost).toHaveBeenCalledWith("/api/projects", body);
+    expect(result).toEqual(mockProject);
+  });
+});
+
+describe("listProjects", () => {
+  it("calls apiGet with correct query params using defaults", async () => {
+    vi.mocked(apiGet).mockResolvedValue([mockProject]);
+
+    const result = await listProjects("user-1");
+
+    expect(apiGet).toHaveBeenCalledWith(
+      "/api/projects?user_id=user-1&offset=0&limit=100",
+    );
+    expect(result).toEqual([mockProject]);
+  });
+
+  it("calls apiGet with custom offset and limit", async () => {
+    vi.mocked(apiGet).mockResolvedValue([]);
+
+    await listProjects("user-1", 10, 25);
+
+    expect(apiGet).toHaveBeenCalledWith(
+      "/api/projects?user_id=user-1&offset=10&limit=25",
+    );
+  });
+});
+
+describe("getProject", () => {
+  it("calls apiGet with /api/projects/{id}", async () => {
+    vi.mocked(apiGet).mockResolvedValue(mockProject);
+
+    const result = await getProject("proj-1");
+
+    expect(apiGet).toHaveBeenCalledWith("/api/projects/proj-1");
+    expect(result).toEqual(mockProject);
+  });
+});
+
+describe("updateProject", () => {
+  it("calls apiPatch with /api/projects/{id} and body", async () => {
+    const updated = { ...mockProject, name: "Updated" };
+    vi.mocked(apiPatch).mockResolvedValue(updated);
+
+    const result = await updateProject("proj-1", { name: "Updated" });
+
+    expect(apiPatch).toHaveBeenCalledWith("/api/projects/proj-1", {
+      name: "Updated",
+    });
+    expect(result).toEqual(updated);
+  });
+});
+
+describe("deleteProject", () => {
+  it("calls apiDelete with /api/projects/{id}", async () => {
+    vi.mocked(apiDelete).mockResolvedValue(undefined);
+
+    await deleteProject("proj-1");
+
+    expect(apiDelete).toHaveBeenCalledWith("/api/projects/proj-1");
+  });
+});

--- a/packages/web/__tests__/unit/create-project-form.test.tsx
+++ b/packages/web/__tests__/unit/create-project-form.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CreateProjectForm } from "@/components/create-project-form";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/lib/api/projects", () => ({
+  createProject: vi.fn(),
+  listProjects: vi.fn(),
+  getProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  );
+}
+
+describe("CreateProjectForm", () => {
+  it("renders project name input and submit button", () => {
+    renderWithProviders(<CreateProjectForm />);
+    expect(screen.getByLabelText(/project name/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /create project/i })
+    ).toBeInTheDocument();
+  });
+
+  it("disables submit button when name is empty", () => {
+    renderWithProviders(<CreateProjectForm />);
+    expect(
+      screen.getByRole("button", { name: /create project/i })
+    ).toBeDisabled();
+  });
+
+  it("enables submit button when name is entered", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CreateProjectForm />);
+    await user.type(screen.getByLabelText(/project name/i), "My Game");
+    expect(
+      screen.getByRole("button", { name: /create project/i })
+    ).toBeEnabled();
+  });
+});

--- a/packages/web/__tests__/unit/game-profile-form.test.tsx
+++ b/packages/web/__tests__/unit/game-profile-form.test.tsx
@@ -4,7 +4,7 @@ import { GameProfileForm } from "@/components/game-profile-form";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 vi.mock("@/lib/api/game-profiles", () => ({
-  getGameProfile: vi.fn().mockRejectedValue(new Error("not found")),
+  getGameProfile: vi.fn().mockResolvedValue(null),
   createGameProfile: vi.fn(),
   updateGameProfile: vi.fn(),
 }));

--- a/packages/web/__tests__/unit/game-profile-form.test.tsx
+++ b/packages/web/__tests__/unit/game-profile-form.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GameProfileForm } from "@/components/game-profile-form";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/lib/api/game-profiles", () => ({
+  getGameProfile: vi.fn().mockRejectedValue(new Error("not found")),
+  createGameProfile: vi.fn(),
+  updateGameProfile: vi.fn(),
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  );
+}
+
+describe("GameProfileForm", () => {
+  it("renders all form fields", async () => {
+    renderWithProviders(<GameProfileForm projectId="proj-1" />);
+    expect(await screen.findByLabelText(/genre/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/target audience/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/art style/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/brand guidelines/i)).toBeInTheDocument();
+  });
+
+  it("shows Create Profile button when no existing profile", async () => {
+    renderWithProviders(<GameProfileForm projectId="proj-1" />);
+    expect(
+      await screen.findByRole("button", { name: /create profile/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/web/__tests__/unit/project-card.test.tsx
+++ b/packages/web/__tests__/unit/project-card.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProjectCard } from "@/components/project-card";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockProject = {
+  id: "proj-1",
+  user_id: "user-1",
+  name: "Test Game",
+  status: "active",
+  created_at: "2026-03-01T00:00:00Z",
+  updated_at: null,
+};
+
+describe("ProjectCard", () => {
+  it("renders project name", () => {
+    render(<ProjectCard project={mockProject} />);
+    expect(screen.getByText("Test Game")).toBeInTheDocument();
+  });
+
+  it("renders status badge", () => {
+    render(<ProjectCard project={mockProject} />);
+    expect(screen.getByText("active")).toBeInTheDocument();
+  });
+
+  it("renders formatted date", () => {
+    render(<ProjectCard project={mockProject} />);
+    // toLocaleDateString output varies by locale, just check "Created" prefix exists
+    expect(screen.getByText(/Created/)).toBeInTheDocument();
+  });
+
+  it("links to project detail page", () => {
+    render(<ProjectCard project={mockProject} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/projects/proj-1");
+  });
+});

--- a/packages/web/__tests__/unit/sidebar.test.tsx
+++ b/packages/web/__tests__/unit/sidebar.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Sidebar } from "@/components/sidebar";
+
+// Mock next/link since we're outside Next.js
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("Sidebar", () => {
+  it("renders Magnet branding", () => {
+    render(<Sidebar />);
+    expect(screen.getByText("Magnet")).toBeInTheDocument();
+  });
+
+  it("renders Projects nav link pointing to /projects", () => {
+    render(<Sidebar />);
+    const link = screen.getByRole("link", { name: /projects/i });
+    expect(link).toHaveAttribute("href", "/projects");
+  });
+
+  it("renders Creative Library as disabled", () => {
+    render(<Sidebar />);
+    expect(screen.getByText(/creative library/i)).toBeInTheDocument();
+    // Should NOT be a link
+    expect(
+      screen.queryByRole("link", { name: /creative library/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders Settings as disabled", () => {
+    render(<Sidebar />);
+    expect(screen.getByText(/settings/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /settings/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders user avatar area", () => {
+    render(<Sidebar />);
+    expect(screen.getByText("U")).toBeInTheDocument();
+  });
+});

--- a/packages/web/__tests__/unit/use-game-profile.test.tsx
+++ b/packages/web/__tests__/unit/use-game-profile.test.tsx
@@ -1,0 +1,124 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+import {
+  useGameProfile,
+  useCreateGameProfile,
+  useUpdateGameProfile,
+} from "@/lib/hooks/use-game-profile";
+import {
+  getGameProfile,
+  createGameProfile,
+  updateGameProfile,
+} from "@/lib/api/game-profiles";
+import type { GameProfile } from "@/lib/types/game-profile";
+
+vi.mock("@/lib/api/game-profiles", () => ({
+  getGameProfile: vi.fn(),
+  createGameProfile: vi.fn(),
+  updateGameProfile: vi.fn(),
+}));
+
+const mockProfile: GameProfile = {
+  id: "gp-1",
+  project_id: "proj-1",
+  genre: "puzzle",
+  target_audience: "casual gamers",
+  core_mechanics: ["match-3"],
+  art_style: "cartoon",
+  brand_guidelines: null,
+  competitors: null,
+  key_selling_points: ["relaxing"],
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: null,
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return Wrapper;
+}
+
+describe("useGameProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches game profile for a project", async () => {
+    vi.mocked(getGameProfile).mockResolvedValue(mockProfile);
+
+    const { result } = renderHook(() => useGameProfile("proj-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getGameProfile).toHaveBeenCalledWith("proj-1");
+    expect(result.current.data).toEqual(mockProfile);
+  });
+
+  it("does not fetch when projectId is empty", () => {
+    const { result } = renderHook(() => useGameProfile(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(getGameProfile).not.toHaveBeenCalled();
+  });
+});
+
+describe("useCreateGameProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls createGameProfile with projectId and data", async () => {
+    vi.mocked(createGameProfile).mockResolvedValue(mockProfile);
+
+    const { result } = renderHook(() => useCreateGameProfile("proj-1"), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ genre: "puzzle", target_audience: "casual gamers" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(createGameProfile).toHaveBeenCalledWith("proj-1", {
+      genre: "puzzle",
+      target_audience: "casual gamers",
+    });
+  });
+});
+
+describe("useUpdateGameProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls updateGameProfile with projectId and data", async () => {
+    vi.mocked(updateGameProfile).mockResolvedValue({
+      ...mockProfile,
+      genre: "strategy",
+    });
+
+    const { result } = renderHook(() => useUpdateGameProfile("proj-1"), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ genre: "strategy" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(updateGameProfile).toHaveBeenCalledWith("proj-1", {
+      genre: "strategy",
+    });
+  });
+});

--- a/packages/web/__tests__/unit/use-projects.test.tsx
+++ b/packages/web/__tests__/unit/use-projects.test.tsx
@@ -1,0 +1,174 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+import {
+  useProjects,
+  useProject,
+  useCreateProject,
+  useUpdateProject,
+  useDeleteProject,
+} from "@/lib/hooks/use-projects";
+import {
+  listProjects,
+  getProject,
+  createProject,
+  updateProject,
+  deleteProject,
+} from "@/lib/api/projects";
+import type { Project } from "@/lib/types/project";
+
+vi.mock("@/lib/api/projects", () => ({
+  listProjects: vi.fn(),
+  getProject: vi.fn(),
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+}));
+
+const mockProject: Project = {
+  id: "proj-1",
+  user_id: "user-1",
+  name: "Test Project",
+  status: "active",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: null,
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return Wrapper;
+}
+
+describe("useProjects", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches projects for a given user", async () => {
+    vi.mocked(listProjects).mockResolvedValue([mockProject]);
+
+    const { result } = renderHook(() => useProjects("user-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listProjects).toHaveBeenCalledWith("user-1");
+    expect(result.current.data).toEqual([mockProject]);
+  });
+
+  it("returns error when listProjects fails", async () => {
+    vi.mocked(listProjects).mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderHook(() => useProjects("user-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches a single project by id", async () => {
+    vi.mocked(getProject).mockResolvedValue(mockProject);
+
+    const { result } = renderHook(() => useProject("proj-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getProject).toHaveBeenCalledWith("proj-1");
+    expect(result.current.data).toEqual(mockProject);
+  });
+
+  it("does not fetch when id is empty", () => {
+    const { result } = renderHook(() => useProject(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(getProject).not.toHaveBeenCalled();
+  });
+});
+
+describe("useCreateProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls createProject with correct data", async () => {
+    vi.mocked(createProject).mockResolvedValue(mockProject);
+
+    const { result } = renderHook(() => useCreateProject(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ name: "Test Project", user_id: "user-1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(createProject).toHaveBeenCalledWith({
+      name: "Test Project",
+      user_id: "user-1",
+    });
+  });
+});
+
+describe("useUpdateProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls updateProject with id and data", async () => {
+    vi.mocked(updateProject).mockResolvedValue({
+      ...mockProject,
+      name: "Updated",
+    });
+
+    const { result } = renderHook(() => useUpdateProject("proj-1"), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ name: "Updated" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(updateProject).toHaveBeenCalledWith("proj-1", { name: "Updated" });
+  });
+});
+
+describe("useDeleteProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls deleteProject with correct id", async () => {
+    vi.mocked(deleteProject).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteProject(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("proj-1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteProject).toHaveBeenCalledWith("proj-1");
+  });
+});

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -1,0 +1,38 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+    --radius: 0.5rem;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 
 import { Providers } from '@/components/providers';
+import { AppShell } from '@/components/app-shell';
 
 export const metadata = {
   title: 'Magnet',
@@ -11,7 +12,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className="dark">
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          <AppShell>{children}</AppShell>
+        </Providers>
       </body>
     </html>
   );

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,5 +1,7 @@
 import './globals.css';
 
+import { Providers } from '@/components/providers';
+
 export const metadata = {
   title: 'Magnet',
   description: 'Agentic UA creative production platform',
@@ -8,7 +10,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="dark">
-      <body>{children}</body>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,3 +1,5 @@
+import './globals.css';
+
 export const metadata = {
   title: 'Magnet',
   description: 'Agentic UA creative production platform',
@@ -5,7 +7,7 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body>{children}</body>
     </html>
   );

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,8 +1,5 @@
+import { redirect } from "next/navigation";
+
 export default function Home() {
-  return (
-    <main>
-      <h1>Magnet</h1>
-      <p>Agentic UA creative production platform</p>
-    </main>
-  );
+  redirect("/projects");
 }

--- a/packages/web/app/projects/[id]/page.tsx
+++ b/packages/web/app/projects/[id]/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { GameProfileForm } from "@/components/game-profile-form";
+import { useProject } from "@/lib/hooks/use-projects";
+
+export default function ProjectDetailPage() {
+  const params = useParams<{ id: string }>();
+  const { data: project, isLoading, isError } = useProject(params.id);
+
+  if (isLoading) {
+    return <p className="text-muted-foreground">Loading project...</p>;
+  }
+
+  if (isError || !project) {
+    return <p className="text-destructive">Project not found.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <h1 className="text-3xl font-bold">{project.name}</h1>
+        <Badge variant="secondary">{project.status}</Badge>
+      </div>
+      <GameProfileForm projectId={project.id} />
+    </div>
+  );
+}

--- a/packages/web/app/projects/new/page.tsx
+++ b/packages/web/app/projects/new/page.tsx
@@ -1,0 +1,10 @@
+import { CreateProjectForm } from "@/components/create-project-form";
+
+export default function NewProjectPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">New Project</h1>
+      <CreateProjectForm />
+    </div>
+  );
+}

--- a/packages/web/app/projects/page.tsx
+++ b/packages/web/app/projects/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { useProjects } from "@/lib/hooks/use-projects";
+import { ProjectCard } from "@/components/project-card";
+import { Button } from "@/components/ui/button";
+import { STUB_USER_ID } from "@/lib/constants";
+
+export default function ProjectsPage() {
+  const { data: projects, isLoading, isError, error } = useProjects(STUB_USER_ID);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <p className="text-muted-foreground">Loading projects...</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <p className="text-destructive">
+          Failed to load projects: {error instanceof Error ? error.message : "Unknown error"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Projects</h1>
+        <Link href="/projects/new">
+          <Button>New Project</Button>
+        </Link>
+      </div>
+
+      {projects && projects.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {projects.map((project) => (
+            <ProjectCard key={project.id} project={project} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center h-64 space-y-4">
+          <p className="text-muted-foreground">No projects yet.</p>
+          <Link href="/projects/new">
+            <Button>Create your first project</Button>
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/components.json
+++ b/packages/web/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "zinc",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/packages/web/components/app-shell.tsx
+++ b/packages/web/components/app-shell.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { Sidebar } from "@/components/sidebar";
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-screen">
+      <Sidebar />
+      <main className="flex-1 overflow-y-auto px-8 py-6">
+        <div className="mx-auto max-w-5xl">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/packages/web/components/create-project-form.tsx
+++ b/packages/web/components/create-project-form.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { useCreateProject } from "@/lib/hooks/use-projects";
+import { STUB_USER_ID } from "@/lib/constants";
+
+export function CreateProjectForm() {
+  const [name, setName] = useState("");
+  const router = useRouter();
+  const createProject = useCreateProject();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    createProject.mutate(
+      { name: name.trim(), user_id: STUB_USER_ID },
+      {
+        onSuccess: (project) => {
+          router.push(`/projects/${project.id}`);
+        },
+      }
+    );
+  };
+
+  return (
+    <Card className="max-w-lg">
+      <CardHeader>
+        <CardTitle>Create New Project</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="project-name">Project Name</Label>
+            <Input
+              id="project-name"
+              placeholder="My Game"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+          <Button
+            type="submit"
+            disabled={createProject.isPending || !name.trim()}
+          >
+            {createProject.isPending ? "Creating..." : "Create Project"}
+          </Button>
+          {createProject.isError && (
+            <p className="text-sm text-destructive">
+              Failed to create project. Please try again.
+            </p>
+          )}
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/components/game-profile-form.tsx
+++ b/packages/web/components/game-profile-form.tsx
@@ -19,9 +19,10 @@ interface GameProfileFormProps {
 }
 
 export function GameProfileForm({ projectId }: GameProfileFormProps) {
-  const { data: profile, isLoading } = useGameProfile(projectId);
+  const { data: profile, isLoading, isError } = useGameProfile(projectId);
   const createProfile = useCreateGameProfile(projectId);
   const updateProfile = useUpdateGameProfile(projectId);
+  const [jsonError, setJsonError] = useState("");
 
   const [form, setForm] = useState<GameProfileCreate>({
     genre: "",
@@ -50,18 +51,36 @@ export function GameProfileForm({ projectId }: GameProfileFormProps) {
           ? JSON.stringify(profile.brand_guidelines, null, 2)
           : ""
       );
+    } else if (!isLoading && !isError) {
+      setForm({
+        genre: "",
+        target_audience: "",
+        core_mechanics: [],
+        art_style: "",
+        brand_guidelines: {},
+        competitors: [],
+        key_selling_points: [],
+      });
+      setBrandGuidelinesText("");
     }
-  }, [profile]);
+  }, [profile, isLoading, isError]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    setJsonError("");
     let brandGuidelines: Record<string, unknown> = {};
-    try {
-      brandGuidelines = brandGuidelinesText
-        ? JSON.parse(brandGuidelinesText)
-        : {};
-    } catch {
-      // invalid JSON — use empty object
+    if (brandGuidelinesText.trim()) {
+      try {
+        const parsed = JSON.parse(brandGuidelinesText);
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          setJsonError("Brand guidelines must be a JSON object.");
+          return;
+        }
+        brandGuidelines = parsed;
+      } catch {
+        setJsonError("Invalid JSON in brand guidelines.");
+        return;
+      }
     }
     const data: GameProfileCreate = {
       ...form,
@@ -78,6 +97,10 @@ export function GameProfileForm({ projectId }: GameProfileFormProps) {
 
   if (isLoading) {
     return <p className="text-muted-foreground">Loading game profile...</p>;
+  }
+
+  if (isError) {
+    return <p className="text-destructive">Failed to load game profile.</p>;
   }
 
   return (
@@ -134,6 +157,9 @@ export function GameProfileForm({ projectId }: GameProfileFormProps) {
               placeholder='{"primary_color": "#FF5733"}'
               rows={3}
             />
+            {jsonError && (
+              <p className="text-sm text-destructive">{jsonError}</p>
+            )}
           </div>
           <div className="space-y-2">
             <Label htmlFor="competitors">Competitors</Label>

--- a/packages/web/components/game-profile-form.tsx
+++ b/packages/web/components/game-profile-form.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { TagInput } from "@/components/tag-input";
+import {
+  useGameProfile,
+  useCreateGameProfile,
+  useUpdateGameProfile,
+} from "@/lib/hooks/use-game-profile";
+import type { GameProfileCreate } from "@/lib/types/game-profile";
+
+interface GameProfileFormProps {
+  projectId: string;
+}
+
+export function GameProfileForm({ projectId }: GameProfileFormProps) {
+  const { data: profile, isLoading } = useGameProfile(projectId);
+  const createProfile = useCreateGameProfile(projectId);
+  const updateProfile = useUpdateGameProfile(projectId);
+
+  const [form, setForm] = useState<GameProfileCreate>({
+    genre: "",
+    target_audience: "",
+    core_mechanics: [],
+    art_style: "",
+    brand_guidelines: {},
+    competitors: [],
+    key_selling_points: [],
+  });
+  const [brandGuidelinesText, setBrandGuidelinesText] = useState("");
+
+  useEffect(() => {
+    if (profile) {
+      setForm({
+        genre: profile.genre || "",
+        target_audience: profile.target_audience || "",
+        core_mechanics: profile.core_mechanics || [],
+        art_style: profile.art_style || "",
+        brand_guidelines: profile.brand_guidelines || {},
+        competitors: profile.competitors || [],
+        key_selling_points: profile.key_selling_points || [],
+      });
+      setBrandGuidelinesText(
+        profile.brand_guidelines
+          ? JSON.stringify(profile.brand_guidelines, null, 2)
+          : ""
+      );
+    }
+  }, [profile]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    let brandGuidelines: Record<string, unknown> = {};
+    try {
+      brandGuidelines = brandGuidelinesText
+        ? JSON.parse(brandGuidelinesText)
+        : {};
+    } catch {
+      // keep empty if invalid JSON
+    }
+    const data: GameProfileCreate = {
+      ...form,
+      brand_guidelines: brandGuidelines,
+    };
+    if (profile) {
+      updateProfile.mutate(data);
+    } else {
+      createProfile.mutate(data);
+    }
+  };
+
+  const isPending = createProfile.isPending || updateProfile.isPending;
+
+  if (isLoading) {
+    return <p className="text-muted-foreground">Loading game profile...</p>;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Game Profile</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="genre">Genre</Label>
+            <Input
+              id="genre"
+              value={form.genre || ""}
+              onChange={(e) => setForm({ ...form, genre: e.target.value })}
+              placeholder="e.g. Puzzle, RPG, Strategy"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="target-audience">Target Audience</Label>
+            <Input
+              id="target-audience"
+              value={form.target_audience || ""}
+              onChange={(e) =>
+                setForm({ ...form, target_audience: e.target.value })
+              }
+              placeholder="e.g. Casual gamers 25-45"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="core-mechanics">Core Mechanics</Label>
+            <TagInput
+              id="core-mechanics"
+              value={form.core_mechanics || []}
+              onChange={(tags) => setForm({ ...form, core_mechanics: tags })}
+              placeholder="Type and press Enter"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="art-style">Art Style</Label>
+            <Input
+              id="art-style"
+              value={form.art_style || ""}
+              onChange={(e) => setForm({ ...form, art_style: e.target.value })}
+              placeholder="e.g. Cartoon, Realistic, Pixel art"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="brand-guidelines">Brand Guidelines (JSON)</Label>
+            <Textarea
+              id="brand-guidelines"
+              value={brandGuidelinesText}
+              onChange={(e) => setBrandGuidelinesText(e.target.value)}
+              placeholder='{"primary_color": "#FF5733"}'
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="competitors">Competitors</Label>
+            <TagInput
+              id="competitors"
+              value={form.competitors || []}
+              onChange={(tags) => setForm({ ...form, competitors: tags })}
+              placeholder="Type and press Enter"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="key-selling-points">Key Selling Points</Label>
+            <TagInput
+              id="key-selling-points"
+              value={form.key_selling_points || []}
+              onChange={(tags) =>
+                setForm({ ...form, key_selling_points: tags })
+              }
+              placeholder="Type and press Enter"
+            />
+          </div>
+          <Button type="submit" disabled={isPending}>
+            {isPending
+              ? "Saving..."
+              : profile
+                ? "Update Profile"
+                : "Create Profile"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/components/game-profile-form.tsx
+++ b/packages/web/components/game-profile-form.tsx
@@ -61,7 +61,7 @@ export function GameProfileForm({ projectId }: GameProfileFormProps) {
         ? JSON.parse(brandGuidelinesText)
         : {};
     } catch {
-      // keep empty if invalid JSON
+      // invalid JSON — use empty object
     }
     const data: GameProfileCreate = {
       ...form,

--- a/packages/web/components/project-card.tsx
+++ b/packages/web/components/project-card.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link from "next/link";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { Project } from "@/lib/types/project";
+
+interface ProjectCardProps {
+  project: Project;
+}
+
+export function ProjectCard({ project }: ProjectCardProps) {
+  return (
+    <Link href={`/projects/${project.id}`}>
+      <Card className="hover:border-primary/50 transition-colors cursor-pointer">
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg">{project.name}</CardTitle>
+            <Badge variant="secondary">{project.status}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Created {new Date(project.created_at).toLocaleDateString()}
+          </p>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/packages/web/components/providers.tsx
+++ b/packages/web/components/providers.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+            retry: 1,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { FolderKanban, Film, Settings } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+
+export function Sidebar() {
+  return (
+    <aside className="flex h-full w-64 flex-col bg-card text-card-foreground">
+      {/* Branding */}
+      <div className="px-6 py-5">
+        <span className="text-xl font-bold tracking-tight">Magnet</span>
+      </div>
+
+      <Separator />
+
+      {/* Navigation */}
+      <nav className="flex-1 space-y-1 px-3 py-4">
+        {/* Projects — active link */}
+        <Link
+          href="/projects"
+          className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <FolderKanban className="h-4 w-4" />
+          Projects
+        </Link>
+
+        {/* Creative Library — disabled / coming soon */}
+        <div className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground cursor-not-allowed">
+          <Film className="h-4 w-4" />
+          Creative Library
+          <span className="ml-auto text-xs">Soon</span>
+        </div>
+
+        {/* Settings — disabled / coming soon */}
+        <div className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground cursor-not-allowed">
+          <Settings className="h-4 w-4" />
+          Settings
+          <span className="ml-auto text-xs">Soon</span>
+        </div>
+      </nav>
+
+      <Separator />
+
+      {/* User avatar stub */}
+      <div className="flex items-center gap-3 px-6 py-4">
+        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-sm font-medium">
+          U
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -7,16 +7,13 @@ import { Separator } from "@/components/ui/separator";
 export function Sidebar() {
   return (
     <aside className="flex h-full w-64 flex-col bg-card text-card-foreground">
-      {/* Branding */}
       <div className="px-6 py-5">
         <span className="text-xl font-bold tracking-tight">Magnet</span>
       </div>
 
       <Separator />
 
-      {/* Navigation */}
       <nav className="flex-1 space-y-1 px-3 py-4">
-        {/* Projects — active link */}
         <Link
           href="/projects"
           className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
@@ -25,14 +22,12 @@ export function Sidebar() {
           Projects
         </Link>
 
-        {/* Creative Library — disabled / coming soon */}
         <div className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground cursor-not-allowed">
           <Film className="h-4 w-4" />
           Creative Library
           <span className="ml-auto text-xs">Soon</span>
         </div>
 
-        {/* Settings — disabled / coming soon */}
         <div className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground cursor-not-allowed">
           <Settings className="h-4 w-4" />
           Settings
@@ -42,7 +37,6 @@ export function Sidebar() {
 
       <Separator />
 
-      {/* User avatar stub */}
       <div className="flex items-center gap-3 px-6 py-4">
         <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-sm font-medium">
           U

--- a/packages/web/components/tag-input.tsx
+++ b/packages/web/components/tag-input.tsx
@@ -18,8 +18,8 @@ export function TagInput({ value, onChange, placeholder, id }: TagInputProps) {
     const tag = input.trim();
     if (tag && !value.includes(tag)) {
       onChange([...value, tag]);
-      setInput("");
     }
+    setInput("");
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {

--- a/packages/web/components/tag-input.tsx
+++ b/packages/web/components/tag-input.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState, KeyboardEvent } from "react";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+
+interface TagInputProps {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+  id?: string;
+}
+
+export function TagInput({ value, onChange, placeholder, id }: TagInputProps) {
+  const [input, setInput] = useState("");
+
+  const addTag = () => {
+    const tag = input.trim();
+    if (tag && !value.includes(tag)) {
+      onChange([...value, tag]);
+      setInput("");
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addTag();
+    }
+    if (e.key === "Backspace" && !input && value.length > 0) {
+      onChange(value.slice(0, -1));
+    }
+  };
+
+  const removeTag = (tag: string) => {
+    onChange(value.filter((t) => t !== tag));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1">
+        {value.map((tag) => (
+          <Badge
+            key={tag}
+            variant="secondary"
+            className="cursor-pointer"
+            onClick={() => removeTag(tag)}
+          >
+            {tag} ×
+          </Badge>
+        ))}
+      </div>
+      <Input
+        id={id}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={addTag}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}

--- a/packages/web/components/tag-input.tsx
+++ b/packages/web/components/tag-input.tsx
@@ -39,9 +39,9 @@ export function TagInput({ value, onChange, placeholder, id }: TagInputProps) {
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap gap-1">
-        {value.map((tag) => (
+        {value.map((tag, index) => (
           <Badge
-            key={tag}
+            key={`${tag}-${index}`}
             variant="secondary"
             className="cursor-pointer"
             onClick={() => removeTag(tag)}

--- a/packages/web/components/ui/badge.tsx
+++ b/packages/web/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/packages/web/components/ui/button.tsx
+++ b/packages/web/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/packages/web/components/ui/card.tsx
+++ b/packages/web/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/packages/web/components/ui/card.tsx
+++ b/packages/web/components/ui/card.tsx
@@ -30,7 +30,7 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h3

--- a/packages/web/components/ui/input.tsx
+++ b/packages/web/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/packages/web/components/ui/label.tsx
+++ b/packages/web/components/ui/label.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+);
+
+export interface LabelProps
+  extends React.LabelHTMLAttributes<HTMLLabelElement>,
+    VariantProps<typeof labelVariants> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <label
+        ref={ref}
+        className={cn(labelVariants(), className)}
+        {...props}
+      />
+    );
+  }
+);
+Label.displayName = "Label";
+
+export { Label };

--- a/packages/web/components/ui/separator.tsx
+++ b/packages/web/components/ui/separator.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical";
+  decorative?: boolean;
+}
+
+const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <div
+      ref={ref}
+      role={decorative ? "none" : "separator"}
+      aria-orientation={decorative ? undefined : orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Separator.displayName = "Separator";
+
+export { Separator };

--- a/packages/web/components/ui/textarea.tsx
+++ b/packages/web/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -1,0 +1,51 @@
+function getBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+}
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export async function apiGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${getBaseUrl()}${path}`);
+  if (!res.ok) {
+    throw new ApiError(res.status, await res.text());
+  }
+  return res.json();
+}
+
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${getBaseUrl()}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new ApiError(res.status, await res.text());
+  }
+  return res.json();
+}
+
+export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${getBaseUrl()}${path}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new ApiError(res.status, await res.text());
+  }
+  return res.json();
+}
+
+export async function apiDelete(path: string): Promise<void> {
+  const res = await fetch(`${getBaseUrl()}${path}`, { method: "DELETE" });
+  if (!res.ok) {
+    throw new ApiError(res.status, await res.text());
+  }
+}

--- a/packages/web/lib/api/game-profiles.ts
+++ b/packages/web/lib/api/game-profiles.ts
@@ -1,0 +1,30 @@
+import type {
+  GameProfile,
+  GameProfileCreate,
+  GameProfileUpdate,
+} from "@/lib/types/game-profile";
+import { apiGet, apiPost, apiPatch } from "./client";
+
+export async function createGameProfile(
+  projectId: string,
+  data: GameProfileCreate,
+): Promise<GameProfile> {
+  return apiPost<GameProfile>(
+    `/api/projects/${projectId}/game-profile`,
+    data,
+  );
+}
+
+export async function getGameProfile(projectId: string): Promise<GameProfile> {
+  return apiGet<GameProfile>(`/api/projects/${projectId}/game-profile`);
+}
+
+export async function updateGameProfile(
+  projectId: string,
+  data: GameProfileUpdate,
+): Promise<GameProfile> {
+  return apiPatch<GameProfile>(
+    `/api/projects/${projectId}/game-profile`,
+    data,
+  );
+}

--- a/packages/web/lib/api/projects.ts
+++ b/packages/web/lib/api/projects.ts
@@ -1,0 +1,35 @@
+import type {
+  Project,
+  ProjectCreate,
+  ProjectUpdate,
+} from "@/lib/types/project";
+import { apiGet, apiPost, apiPatch, apiDelete } from "./client";
+
+export async function createProject(data: ProjectCreate): Promise<Project> {
+  return apiPost<Project>("/api/projects", data);
+}
+
+export async function listProjects(
+  userId: string,
+  offset = 0,
+  limit = 100,
+): Promise<Project[]> {
+  return apiGet<Project[]>(
+    `/api/projects?user_id=${userId}&offset=${offset}&limit=${limit}`,
+  );
+}
+
+export async function getProject(id: string): Promise<Project> {
+  return apiGet<Project>(`/api/projects/${id}`);
+}
+
+export async function updateProject(
+  id: string,
+  data: ProjectUpdate,
+): Promise<Project> {
+  return apiPatch<Project>(`/api/projects/${id}`, data);
+}
+
+export async function deleteProject(id: string): Promise<void> {
+  return apiDelete(`/api/projects/${id}`);
+}

--- a/packages/web/lib/api/projects.ts
+++ b/packages/web/lib/api/projects.ts
@@ -14,9 +14,12 @@ export async function listProjects(
   offset = 0,
   limit = 100,
 ): Promise<Project[]> {
-  return apiGet<Project[]>(
-    `/api/projects?user_id=${userId}&offset=${offset}&limit=${limit}`,
-  );
+  const params = new URLSearchParams({
+    user_id: userId,
+    offset: String(offset),
+    limit: String(limit),
+  });
+  return apiGet<Project[]>(`/api/projects?${params}`);
 }
 
 export async function getProject(id: string): Promise<Project> {

--- a/packages/web/lib/constants.ts
+++ b/packages/web/lib/constants.ts
@@ -1,2 +1,3 @@
-/** Stub user ID used during development before auth is wired up. */
-export const STUB_USER_ID = "00000000-0000-0000-0000-000000000000";
+// TODO: Replace with Clerk auth — this stub is for development only
+export const STUB_USER_ID =
+  process.env.NEXT_PUBLIC_STUB_USER_ID || "00000000-0000-0000-0000-000000000000";

--- a/packages/web/lib/constants.ts
+++ b/packages/web/lib/constants.ts
@@ -1,0 +1,2 @@
+/** Stub user ID used during development before auth is wired up. */
+export const STUB_USER_ID = "00000000-0000-0000-0000-000000000000";

--- a/packages/web/lib/hooks/use-game-profile.ts
+++ b/packages/web/lib/hooks/use-game-profile.ts
@@ -1,0 +1,45 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  getGameProfile,
+  createGameProfile,
+  updateGameProfile,
+} from "@/lib/api/game-profiles";
+import type {
+  GameProfileCreate,
+  GameProfileUpdate,
+} from "@/lib/types/game-profile";
+
+export function useGameProfile(projectId: string) {
+  return useQuery({
+    queryKey: ["game-profile", projectId],
+    queryFn: () => getGameProfile(projectId),
+    enabled: !!projectId,
+  });
+}
+
+export function useCreateGameProfile(projectId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: GameProfileCreate) =>
+      createGameProfile(projectId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["game-profile", projectId],
+      });
+    },
+  });
+}
+
+export function useUpdateGameProfile(projectId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: GameProfileUpdate) =>
+      updateGameProfile(projectId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["game-profile", projectId],
+      });
+    },
+  });
+}

--- a/packages/web/lib/hooks/use-projects.ts
+++ b/packages/web/lib/hooks/use-projects.ts
@@ -11,14 +11,14 @@ import type { ProjectCreate, ProjectUpdate } from "@/lib/types/project";
 
 export function useProjects(userId: string) {
   return useQuery({
-    queryKey: ["projects", userId],
+    queryKey: ["projects", "list", userId],
     queryFn: () => listProjects(userId),
   });
 }
 
 export function useProject(id: string) {
   return useQuery({
-    queryKey: ["projects", id],
+    queryKey: ["projects", "detail", id],
     queryFn: () => getProject(id),
     enabled: !!id,
   });

--- a/packages/web/lib/hooks/use-projects.ts
+++ b/packages/web/lib/hooks/use-projects.ts
@@ -1,0 +1,55 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  listProjects,
+  getProject,
+  createProject,
+  updateProject,
+  deleteProject,
+} from "@/lib/api/projects";
+import type { ProjectCreate, ProjectUpdate } from "@/lib/types/project";
+
+export function useProjects(userId: string) {
+  return useQuery({
+    queryKey: ["projects", userId],
+    queryFn: () => listProjects(userId),
+  });
+}
+
+export function useProject(id: string) {
+  return useQuery({
+    queryKey: ["projects", id],
+    queryFn: () => getProject(id),
+    enabled: !!id,
+  });
+}
+
+export function useCreateProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: ProjectCreate) => createProject(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+}
+
+export function useUpdateProject(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: ProjectUpdate) => updateProject(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+}
+
+export function useDeleteProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteProject(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+}

--- a/packages/web/lib/types/game-profile.ts
+++ b/packages/web/lib/types/game-profile.ts
@@ -1,0 +1,25 @@
+export interface GameProfile {
+  id: string;
+  project_id: string;
+  genre: string | null;
+  target_audience: string | null;
+  core_mechanics: string[] | null;
+  art_style: string | null;
+  brand_guidelines: Record<string, unknown> | null;
+  competitors: string[] | null;
+  key_selling_points: string[] | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface GameProfileCreate {
+  genre?: string | null;
+  target_audience?: string | null;
+  core_mechanics?: string[] | null;
+  art_style?: string | null;
+  brand_guidelines?: Record<string, unknown> | null;
+  competitors?: string[] | null;
+  key_selling_points?: string[] | null;
+}
+
+export type GameProfileUpdate = GameProfileCreate;

--- a/packages/web/lib/types/project.ts
+++ b/packages/web/lib/types/project.ts
@@ -1,0 +1,18 @@
+export interface Project {
+  id: string;
+  user_id: string;
+  name: string;
+  status: string;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface ProjectCreate {
+  name: string;
+  user_id: string;
+}
+
+export interface ProjectUpdate {
+  name?: string;
+  status?: string;
+}

--- a/packages/web/lib/utils.ts
+++ b/packages/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
+        "@tanstack/react-query": "^5.90.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
@@ -1938,6 +1939,32 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20.0.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
@@ -2090,6 +2091,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -8,9 +8,15 @@
       "name": "magnet-web",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.4",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.577.0",
         "next": "^14.2.0",
         "react": "^18.3.0",
-        "react-dom": "^18.3.0"
+        "react-dom": "^18.3.0",
+        "tailwind-merge": "^3.5.0",
+        "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -48,7 +54,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1237,7 +1242,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1259,7 +1263,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1269,14 +1272,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1460,7 +1461,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1474,7 +1474,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1484,7 +1483,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1513,6 +1511,39 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2126,14 +2157,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2938,14 +2969,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2959,7 +2988,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -2972,7 +3000,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3286,7 +3313,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3310,7 +3336,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3438,7 +3463,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3517,7 +3541,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -3542,7 +3565,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3551,11 +3573,32 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3581,7 +3624,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3648,7 +3690,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -3687,7 +3728,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3861,7 +3902,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
@@ -3878,7 +3918,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -4673,7 +4712,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4690,7 +4728,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4717,7 +4754,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4727,7 +4763,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -4758,7 +4793,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4864,7 +4898,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4879,7 +4912,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5057,7 +5089,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5236,7 +5267,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5435,7 +5465,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -5501,7 +5530,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -5552,7 +5580,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5608,7 +5635,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5647,7 +5673,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5900,7 +5925,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -6077,7 +6101,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -6090,7 +6113,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/local-pkg": {
@@ -6165,6 +6187,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -6214,7 +6245,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -6224,7 +6254,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6238,7 +6267,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6334,7 +6362,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -6491,7 +6518,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6530,7 +6556,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6540,7 +6565,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6813,7 +6837,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -6867,7 +6890,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6880,7 +6902,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6890,7 +6911,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6929,7 +6949,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6958,7 +6977,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -6976,7 +6994,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7002,7 +7019,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7045,7 +7061,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7071,7 +7086,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -7085,7 +7099,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -7175,7 +7188,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7238,7 +7250,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -7248,7 +7259,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -7261,7 +7271,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7342,7 +7351,6 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -7383,7 +7391,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7478,7 +7485,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8111,7 +8117,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -8147,7 +8152,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8163,11 +8167,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -8201,6 +8214,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8212,7 +8234,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -8222,7 +8243,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -8242,7 +8262,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -8299,7 +8318,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -8351,7 +8369,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -8637,7 +8654,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -19,10 +19,13 @@
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.2.0",
+        "autoprefixer": "^10.4.27",
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.0",
         "jsdom": "^28.1.0",
+        "postcss": "^8.5.8",
         "prettier": "^3.2.0",
+        "tailwindcss": "^3.4.19",
         "typescript": "^5.4.0",
         "vitest": "^1.4.0"
       }
@@ -40,6 +43,19 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.0.1",
@@ -2918,6 +2934,47 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3122,6 +3179,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3188,6 +3282,19 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3197,6 +3304,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -3314,6 +3434,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001777",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
@@ -3383,6 +3513,44 @@
         "node": "*"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3408,6 +3576,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3465,6 +3643,19 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/cssstyle": {
       "version": "6.2.0",
@@ -3666,6 +3857,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -3675,6 +3873,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -4464,6 +4669,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4517,6 +4752,19 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -4589,6 +4837,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fs.realpath": {
@@ -5169,6 +5431,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
@@ -5366,6 +5641,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -5611,6 +5896,16 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5778,6 +6073,26 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/local-pkg": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
@@ -5895,6 +6210,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -5977,6 +6329,18 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -6069,6 +6433,34 @@
         }
       }
     },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -6094,6 +6486,16 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -6132,6 +6534,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -6464,6 +6876,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -6494,9 +6926,10 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6513,13 +6946,147 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -6665,6 +7232,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/redent": {
@@ -7504,6 +8107,29 @@
         }
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7537,12 +8163,73 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7608,6 +8295,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
@@ -7646,6 +8346,13 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -7925,6 +8632,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -8455,35 +9169,6 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
-    "node_modules/vite-node/node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/vite-node/node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
@@ -8542,36 +9227,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {
@@ -9068,35 +9723,6 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
-      }
-    },
-    "node_modules/vitest/node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
+    "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,10 +22,13 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.27",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.0",
     "jsdom": "^28.1.0",
+    "postcss": "^8.5.8",
     "prettier": "^3.2.0",
+    "tailwindcss": "^3.4.19",
     "typescript": "^5.4.0",
     "vitest": "^1.4.0"
   }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,9 +11,15 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.577.0",
     "next": "^14.2.0",
     "react": "^18.3.0",
-    "react-dom": "^18.3.0"
+    "react-dom": "^18.3.0",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/web/postcss.config.js
+++ b/packages/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -51,7 +51,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [require("tailwindcss-animate")],
 };
 
 export default config;

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -1,0 +1,57 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  darkMode: 'class',
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './lib/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -35,6 +35,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "vitest.config.ts"
   ]
 }

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,11 +17,24 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
+    setupFiles: ["./__tests__/setup.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Set up the complete frontend foundation: Tailwind CSS 3 (dark theme), shadcn/ui (new-york style), and 7 base UI components
- Built a typed API client layer with fetch wrapper and functions for Projects and GameProfiles
- Added React Query (TanStack Query) with custom hooks for all project/game-profile CRUD operations
- Created the app shell with dark sidebar navigation and responsive layout
- Implemented the Project Setup flow: projects list, create project form, and project detail page with full game profile form (genre, audience, mechanics, art style, brand guidelines, competitors, key selling points)

## Changes

**New files (38):**
- `tailwind.config.ts`, `postcss.config.js`, `app/globals.css` — Tailwind + dark theme
- `components.json`, `lib/utils.ts` — shadcn/ui config
- `components/ui/{button,input,label,card,textarea,badge,separator}.tsx` — UI components
- `lib/types/{project,game-profile}.ts` — TypeScript types matching backend schemas
- `lib/api/{client,projects,game-profiles}.ts` — API client layer
- `lib/hooks/{use-projects,use-game-profile}.ts` — React Query hooks
- `lib/constants.ts` — Stubbed auth user ID
- `components/{providers,app-shell,sidebar,project-card,create-project-form,game-profile-form,tag-input}.tsx` — App components
- `app/projects/page.tsx`, `app/projects/new/page.tsx`, `app/projects/[id]/page.tsx` — Pages
- `__tests__/unit/{api-client,api-projects,use-projects,use-game-profile,sidebar,project-card,create-project-form,game-profile-form}.test.{ts,tsx}` — Tests
- `vitest.config.ts`, `__tests__/setup.ts` — Test infrastructure

**Modified files (4):**
- `app/layout.tsx` — Added globals.css, dark class, Providers, AppShell
- `app/page.tsx` — Redirect `/` to `/projects`
- `tsconfig.json` — Excluded vitest.config.ts to fix build
- `package.json` — New dependencies

## Testing
- 46 tests passing (39 new + 7 pre-existing)
- API client: 8 tests (GET/POST/PATCH/DELETE success + error paths)
- API projects: 6 tests (all CRUD functions)
- React Query hooks: 11 tests (projects + game profiles)
- Components: 14 tests (sidebar, project card, create form, game profile form)
- All enforcement checks pass (file size, import direction, no secrets)

## Notes
- Auth is stubbed with a hardcoded user ID (`STUB_USER_ID`) — Clerk integration deferred
- Zustand deferred until multi-screen UI state is needed
- Creative Library and Settings nav items visible but disabled (marked "Soon")
- `vitest.config.ts` excluded from tsconfig due to vite version conflict between vitest and @vitejs/plugin-react

---
Generated with [Agent Harness](https://github.com/Alchemishty/agent-harness)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects list, create, and detail pages with dark-themed app shell and sidebar; root now redirects to Projects
  * In-app game profile create/edit forms with tag inputs and JSON brand-guidelines editor
  * Reusable UI system (buttons, inputs, badges, cards, textarea, separator) plus global Tailwind-based styling and theme tokens
  * Typed API client, project & game-profile hooks, and a React Query provider

* **Documentation**
  * Frontend dashboard design and implementation plan (scope, flows, testing strategy)

* **Tests**
  * Unit and hook tests covering API client, project & game-profile flows, forms, cards, sidebar, and providers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->