### PR TITLE
feat(web): add concept review screen with brief management

### DIFF
--- a/docs/plans/active/2026-04-10-concept-review.md
+++ b/docs/plans/active/2026-04-10-concept-review.md
@@ -1,0 +1,151 @@
+# Concept Review Screen Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a concept review section to the project detail page where users can trigger AI concept generation, browse generated creative briefs, edit/approve/discard them, and view scene plans.
+
+**Architecture:** Extends the project detail page with a concept review section below assets. Uses the existing brief CRUD endpoints and the concept generation trigger. React Query manages brief list state. Each brief is displayed as a card with hook type, script, emotion, and scene plan summary. Users can edit fields inline, change status (draft→approved), or delete briefs.
+
+**Tech Stack:** Next.js 14, TypeScript, Tailwind + shadcn/ui, TanStack React Query, vitest
+
+---
+
+## Assumptions
+- Backend brief endpoints are complete (`POST concepts`, `GET briefs`, `GET/PATCH/DELETE brief`)
+- Concept generation requires a GameProfile with genre and target_audience
+- Scene plan is a JSON dict displayed read-only (editing scene plans is out of scope)
+- The "Generate Concepts" button on the game profile form (currently disabled) will be replaced by one in this section
+
+## Open Questions
+- None — backend is complete, UI patterns are established.
+
+## Context and Orientation
+- **Files to read before starting:** `packages/api/app/schemas/brief.py` (backend types), `packages/web/lib/api/client.ts` (API client pattern), `packages/web/app/projects/[id]/page.tsx` (page to modify)
+- **Patterns to follow:** `docs/conventions/naming.md`, `docs/conventions/import-ordering.md`
+- **Similar existing code:** `lib/api/assets.ts` + `lib/hooks/use-assets.ts` + `components/asset-upload.tsx`
+
+## Steps
+
+### Step 1: Create TypeScript types for Brief
+
+**Files:**
+- Create: `packages/web/lib/types/brief.ts`
+
+**Tests:** No unit tests — type-only file verified by build.
+
+**What to do:** Create TypeScript interfaces mirroring the backend Pydantic schemas:
+- `BriefStatus` — union type: `"draft" | "approved" | "producing" | "complete"`
+- `Brief` — mirrors `BriefRead` (id, project_id, hook_type, narrative_angle, script, voiceover_text, target_emotion, cta_text, reference_ads, target_format, target_duration, status, generated_by, scene_plan, created_at, updated_at)
+- `BriefUpdate` — all fields optional (hook_type, narrative_angle, script, voiceover_text, target_emotion, cta_text, status, scene_plan, target_format, target_duration)
+
+**Verify:** `cd packages/web && npx tsc --noEmit`
+
+---
+
+### Step 2: Build brief API client functions
+
+**Files:**
+- Create: `packages/web/lib/api/briefs.ts`
+- Test: `packages/web/__tests__/unit/api-briefs.test.ts`
+
+**Tests:** Test each function calls the correct API method with the right path. Mock `@/lib/api/client`.
+
+**What to do:** Create typed API functions:
+- `generateConcepts(projectId: string)` → `apiPost<Brief[]>` to `/api/projects/{projectId}/concepts` with empty body
+- `listBriefs(projectId: string, status?: BriefStatus)` → `apiGet<Brief[]>` with optional status query param
+- `getBrief(briefId: string)` → `apiGet<Brief>`
+- `updateBrief(briefId: string, data: BriefUpdate)` → `apiPatch<Brief>`
+- `deleteBrief(briefId: string)` → `apiDelete`
+
+**Verify:** `cd packages/web && npx vitest run __tests__/unit/api-briefs.test.ts`
+
+---
+
+### Step 3: Create React Query hooks for briefs
+
+**Files:**
+- Create: `packages/web/lib/hooks/use-briefs.ts`
+- Test: `packages/web/__tests__/unit/use-briefs.test.tsx`
+
+**Tests:** Test `useBriefs` returns data from `listBriefs`. Test `useGenerateConcepts` calls `generateConcepts`. Test `useUpdateBrief` calls `updateBrief` and invalidates. Test `useDeleteBrief`.
+
+**What to do:** Create hooks:
+- `useBriefs(projectId: string, status?: BriefStatus)` — useQuery with key `["briefs", "list", projectId, status]`
+- `useGenerateConcepts(projectId: string)` — useMutation calling `generateConcepts`, invalidates `["briefs"]`
+- `useUpdateBrief(briefId: string)` — useMutation calling `updateBrief`, invalidates `["briefs"]`
+- `useDeleteBrief()` — useMutation calling `deleteBrief`, invalidates `["briefs"]`
+
+**Verify:** `cd packages/web && npx vitest run __tests__/unit/use-briefs.test.tsx`
+
+---
+
+### Step 4: Build the brief card component
+
+**Files:**
+- Create: `packages/web/components/brief-card.tsx`
+- Test: `packages/web/__tests__/unit/brief-card.test.tsx`
+
+**Tests:** Test renders hook type, script excerpt, status badge. Test renders approve and delete buttons. Test approve button calls updateBrief with status "approved".
+
+**What to do:** Create a `BriefCard` component displaying a single brief:
+- Props: `brief: Brief`, `onApprove: () => void`, `onDelete: () => void`
+- Card layout with:
+  - Header: hook type badge + status badge + generated_by indicator
+  - Body: narrative angle, script (truncated to ~3 lines with expand), target emotion, CTA text
+  - Scene plan summary: count of scenes, list of strategies used (COMPOSE/GENERATE/RENDER)
+  - Footer: target format + duration, Approve button (if draft), Delete button
+- Approve button sets status to "approved" via callback
+- Visual distinction for approved vs draft briefs (border color or opacity)
+
+**Verify:** `cd packages/web && npx vitest run __tests__/unit/brief-card.test.tsx`
+
+---
+
+### Step 5: Build the concept review section component
+
+**Files:**
+- Create: `packages/web/components/concept-review.tsx`
+- Test: `packages/web/__tests__/unit/concept-review.test.tsx`
+
+**Tests:** Test renders "Creative Concepts" title. Test renders "Generate Concepts" button. Test shows empty state when no briefs. Test renders brief cards when briefs exist.
+
+**What to do:** Create a `ConceptReview` component:
+- Props: `projectId: string`
+- Wrapped in Card with "Creative Concepts" title
+- "Generate Concepts" button at top — calls `useGenerateConcepts`, shows loading state while generating
+- Status filter: optional tabs or buttons for All / Draft / Approved (filter via `useBriefs` status param)
+- Grid of `BriefCard` components for each brief
+- Empty state: "No concepts yet. Generate concepts from your game profile."
+- Loading and error states
+- Wire approve/delete callbacks through hooks
+
+**Verify:** `cd packages/web && npx vitest run __tests__/unit/concept-review.test.tsx && npm run build`
+
+---
+
+### Step 6: Add concept review section to project detail page
+
+**Files:**
+- Modify: `packages/web/app/projects/[id]/page.tsx`
+
+**Tests:** No new test file.
+
+**What to do:** Import `ConceptReview` and add it below `AssetUpload` with a `Separator` between them.
+
+**Verify:** `cd packages/web && npm run build`
+
+---
+
+## Validation
+After all steps:
+1. `cd packages/web && npx vitest run` — all tests pass
+2. `cd packages/web && npx eslint .` — no lint errors
+3. `cd packages/web && npm run build` — build succeeds
+4. `bash enforcement/run-all.sh` — all enforcement checks pass
+5. Navigate to `/projects/[id]` — game profile + assets + concept review visible
+6. Click "Generate Concepts" → briefs appear as cards
+7. Click "Approve" on a brief → status changes to approved
+8. Click delete → brief removed
+
+## Decision Log
+(Populated during implementation)

--- a/packages/web/__tests__/unit/api-briefs.test.ts
+++ b/packages/web/__tests__/unit/api-briefs.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Brief, BriefUpdate } from "@/lib/types/brief";
+
+// Mock the client module before importing briefs
+vi.mock("@/lib/api/client", () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+  apiPatch: vi.fn(),
+  apiDelete: vi.fn(),
+}));
+
+import { apiGet, apiPost, apiPatch, apiDelete } from "@/lib/api/client";
+import {
+  generateConcepts,
+  listBriefs,
+  getBrief,
+  updateBrief,
+  deleteBrief,
+} from "@/lib/api/briefs";
+
+const mockBrief: Brief = {
+  id: "brief-1",
+  project_id: "proj-1",
+  hook_type: "fail_challenge",
+  narrative_angle: "Show the player failing then succeeding",
+  script: "Watch me fail... then crush it!",
+  voiceover_text: "Can you beat this level?",
+  target_emotion: "excitement",
+  cta_text: "Download now",
+  reference_ads: [],
+  target_format: "9:16",
+  target_duration: 30,
+  status: "draft",
+  generated_by: "concept_agent",
+  scene_plan: null,
+  created_at: "2026-04-10T00:00:00Z",
+  updated_at: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("generateConcepts", () => {
+  it("calls apiPost with correct path and empty body", async () => {
+    vi.mocked(apiPost).mockResolvedValue([mockBrief]);
+
+    const result = await generateConcepts("proj-1");
+
+    expect(apiPost).toHaveBeenCalledWith(
+      "/api/projects/proj-1/concepts",
+      {},
+    );
+    expect(result).toEqual([mockBrief]);
+  });
+});
+
+describe("listBriefs", () => {
+  it("calls apiGet with correct path when no filter", async () => {
+    vi.mocked(apiGet).mockResolvedValue([mockBrief]);
+
+    const result = await listBriefs("proj-1");
+
+    expect(apiGet).toHaveBeenCalledWith("/api/projects/proj-1/briefs");
+    expect(result).toEqual([mockBrief]);
+  });
+
+  it("calls apiGet with status query param when provided", async () => {
+    vi.mocked(apiGet).mockResolvedValue([mockBrief]);
+
+    const result = await listBriefs("proj-1", "draft");
+
+    expect(apiGet).toHaveBeenCalledWith(
+      "/api/projects/proj-1/briefs?status=draft",
+    );
+    expect(result).toEqual([mockBrief]);
+  });
+});
+
+describe("getBrief", () => {
+  it("calls apiGet with correct path", async () => {
+    vi.mocked(apiGet).mockResolvedValue(mockBrief);
+
+    const result = await getBrief("brief-1");
+
+    expect(apiGet).toHaveBeenCalledWith("/api/briefs/brief-1");
+    expect(result).toEqual(mockBrief);
+  });
+});
+
+describe("updateBrief", () => {
+  it("calls apiPatch with correct path and body", async () => {
+    const updated = { ...mockBrief, status: "approved" as const };
+    vi.mocked(apiPatch).mockResolvedValue(updated);
+
+    const data: BriefUpdate = { status: "approved" };
+    const result = await updateBrief("brief-1", data);
+
+    expect(apiPatch).toHaveBeenCalledWith("/api/briefs/brief-1", data);
+    expect(result).toEqual(updated);
+  });
+});
+
+describe("deleteBrief", () => {
+  it("calls apiDelete with correct path", async () => {
+    vi.mocked(apiDelete).mockResolvedValue(undefined);
+
+    await deleteBrief("brief-1");
+
+    expect(apiDelete).toHaveBeenCalledWith("/api/briefs/brief-1");
+  });
+});

--- a/packages/web/__tests__/unit/brief-card.test.tsx
+++ b/packages/web/__tests__/unit/brief-card.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BriefCard } from "@/components/brief-card";
+
+const mockBrief = {
+  id: "brief-1",
+  project_id: "proj-1",
+  hook_type: "Fail/Challenge",
+  narrative_angle: "Player struggles with level 50",
+  script: "Can you beat this impossible level? Most players give up here.",
+  voiceover_text: "Think you can do better?",
+  target_emotion: "frustration",
+  cta_text: "Download now",
+  reference_ads: [],
+  target_format: "9:16",
+  target_duration: 15,
+  status: "draft" as const,
+  generated_by: "agent",
+  scene_plan: { scenes: [
+    { strategy: "GENERATE", type: "hook", duration: 2 },
+    { strategy: "COMPOSE", type: "real_gameplay", duration: 5 },
+    { strategy: "RENDER", type: "endcard", duration: 2 },
+  ] },
+  created_at: "2026-04-10T00:00:00Z",
+  updated_at: null,
+};
+
+describe("BriefCard", () => {
+  it("renders hook type", () => {
+    render(<BriefCard brief={mockBrief} onApprove={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByText("Fail/Challenge")).toBeInTheDocument();
+  });
+
+  it("renders script text", () => {
+    render(<BriefCard brief={mockBrief} onApprove={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByText(/impossible level/)).toBeInTheDocument();
+  });
+
+  it("renders status badge", () => {
+    render(<BriefCard brief={mockBrief} onApprove={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByText("draft")).toBeInTheDocument();
+  });
+
+  it("renders approve button for draft briefs", () => {
+    render(<BriefCard brief={mockBrief} onApprove={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /approve/i })).toBeInTheDocument();
+  });
+
+  it("does not render approve button for approved briefs", () => {
+    const approved = { ...mockBrief, status: "approved" as const };
+    render(<BriefCard brief={approved} onApprove={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onApprove when approve is clicked", async () => {
+    const onApprove = vi.fn();
+    render(<BriefCard brief={mockBrief} onApprove={onApprove} onDelete={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /approve/i }));
+    expect(onApprove).toHaveBeenCalled();
+  });
+
+  it("renders scene plan summary", () => {
+    render(<BriefCard brief={mockBrief} onApprove={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByText(/3 scenes/)).toBeInTheDocument();
+  });
+});

--- a/packages/web/__tests__/unit/concept-review.test.tsx
+++ b/packages/web/__tests__/unit/concept-review.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ConceptReview } from "@/components/concept-review";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/lib/hooks/use-briefs", () => ({
+  useBriefs: vi.fn(() => ({ data: [], isLoading: false, isError: false })),
+  useGenerateConcepts: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useUpdateBrief: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDeleteBrief: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+describe("ConceptReview", () => {
+  it("renders Creative Concepts title", () => {
+    renderWithProviders(<ConceptReview projectId="proj-1" />);
+    expect(screen.getByText("Creative Concepts")).toBeInTheDocument();
+  });
+
+  it("renders Generate Concepts button", () => {
+    renderWithProviders(<ConceptReview projectId="proj-1" />);
+    expect(screen.getByRole("button", { name: /generate concepts/i })).toBeInTheDocument();
+  });
+
+  it("shows empty state when no briefs", () => {
+    renderWithProviders(<ConceptReview projectId="proj-1" />);
+    expect(screen.getByText(/no concepts yet/i)).toBeInTheDocument();
+  });
+
+  it("renders status filter badges", () => {
+    renderWithProviders(<ConceptReview projectId="proj-1" />);
+    expect(screen.getByText("All")).toBeInTheDocument();
+    expect(screen.getByText("Draft")).toBeInTheDocument();
+    expect(screen.getByText("Approved")).toBeInTheDocument();
+  });
+});

--- a/packages/web/__tests__/unit/use-briefs.test.tsx
+++ b/packages/web/__tests__/unit/use-briefs.test.tsx
@@ -1,0 +1,137 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+import {
+  useBriefs,
+  useGenerateConcepts,
+  useUpdateBrief,
+  useDeleteBrief,
+} from "@/lib/hooks/use-briefs";
+import {
+  listBriefs,
+  generateConcepts,
+  updateBrief,
+  deleteBrief,
+} from "@/lib/api/briefs";
+import type { Brief } from "@/lib/types/brief";
+
+vi.mock("@/lib/api/briefs", () => ({
+  listBriefs: vi.fn(),
+  generateConcepts: vi.fn(),
+  updateBrief: vi.fn(),
+  deleteBrief: vi.fn(),
+}));
+
+const mockBrief: Brief = {
+  id: "brief-1",
+  project_id: "proj-1",
+  hook_type: "fail_challenge",
+  narrative_angle: "Show difficulty then mastery",
+  script: "Watch this impossible level...",
+  voiceover_text: null,
+  target_emotion: "excitement",
+  cta_text: "Download now!",
+  reference_ads: [],
+  target_format: "9:16",
+  target_duration: 30,
+  status: "draft",
+  generated_by: "concept_agent",
+  scene_plan: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: null,
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return Wrapper;
+}
+
+describe("useBriefs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches briefs for a given project", async () => {
+    vi.mocked(listBriefs).mockResolvedValue([mockBrief]);
+
+    const { result } = renderHook(() => useBriefs("proj-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listBriefs).toHaveBeenCalledWith("proj-1", undefined);
+    expect(result.current.data).toEqual([mockBrief]);
+  });
+
+  it("passes status filter to listBriefs", async () => {
+    vi.mocked(listBriefs).mockResolvedValue([mockBrief]);
+
+    const { result } = renderHook(() => useBriefs("proj-1", "approved"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listBriefs).toHaveBeenCalledWith("proj-1", "approved");
+  });
+
+  it("does not fetch when projectId is empty", () => {
+    const { result } = renderHook(() => useBriefs(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(listBriefs).not.toHaveBeenCalled();
+  });
+});
+
+describe("useGenerateConcepts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls generateConcepts with project id", async () => {
+    vi.mocked(generateConcepts).mockResolvedValue([mockBrief]);
+
+    const { result } = renderHook(() => useGenerateConcepts("proj-1"), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(generateConcepts).toHaveBeenCalledWith("proj-1");
+    expect(result.current.data).toEqual([mockBrief]);
+  });
+});
+
+describe("useDeleteBrief", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls deleteBrief with correct id", async () => {
+    vi.mocked(deleteBrief).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteBrief(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("brief-1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteBrief).toHaveBeenCalledWith("brief-1");
+  });
+});

--- a/packages/web/app/projects/[id]/page.tsx
+++ b/packages/web/app/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { GameProfileForm } from "@/components/game-profile-form";
 import { AssetUpload } from "@/components/asset-upload";
+import { ConceptReview } from "@/components/concept-review";
 import { useProject } from "@/lib/hooks/use-projects";
 
 export default function ProjectDetailPage() {
@@ -28,6 +29,8 @@ export default function ProjectDetailPage() {
       <GameProfileForm projectId={project.id} />
       <Separator />
       <AssetUpload projectId={project.id} />
+      <Separator />
+      <ConceptReview projectId={project.id} />
     </div>
   );
 }

--- a/packages/web/components/brief-card.tsx
+++ b/packages/web/components/brief-card.tsx
@@ -1,0 +1,107 @@
+import { Card, CardHeader, CardContent, CardFooter } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Trash2, Check } from "lucide-react";
+import type { Brief } from "@/lib/types/brief";
+
+interface BriefCardProps {
+  brief: Brief;
+  onApprove: () => void;
+  onDelete: () => void;
+}
+
+interface Scene {
+  strategy: string;
+  [key: string]: unknown;
+}
+
+function getStrategyBreakdown(scenes: Scene[]): string {
+  const counts: Record<string, number> = {};
+  for (const scene of scenes) {
+    counts[scene.strategy] = (counts[scene.strategy] || 0) + 1;
+  }
+  return Object.entries(counts)
+    .map(([strategy, count]) => `${count} ${strategy}`)
+    .join(", ");
+}
+
+function getScenePlanSummary(scenePlan: Record<string, unknown> | null): string | null {
+  if (!scenePlan) return null;
+  const scenes = scenePlan.scenes as Scene[] | undefined;
+  if (!Array.isArray(scenes) || scenes.length === 0) return null;
+  const breakdown = getStrategyBreakdown(scenes);
+  return `${scenes.length} scenes: ${breakdown}`;
+}
+
+export function BriefCard({ brief, onApprove, onDelete }: BriefCardProps) {
+  const isApproved = brief.status === "approved";
+  const borderClass = isApproved ? "border-primary" : "";
+  const sceneSummary = getScenePlanSummary(brief.scene_plan);
+
+  return (
+    <Card className={borderClass}>
+      <CardHeader>
+        <div className="flex items-center gap-2 flex-wrap">
+          {brief.hook_type && <Badge variant="outline">{brief.hook_type}</Badge>}
+          <Badge variant={brief.status === "draft" ? "secondary" : "default"}>
+            {brief.status}
+          </Badge>
+          <span className="ml-auto text-xs text-muted-foreground">
+            {brief.generated_by === "agent" ? "AI" : "Human"}
+          </span>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        {brief.narrative_angle && (
+          <div>
+            <span className="text-sm font-bold">Narrative angle: </span>
+            <span className="text-sm">{brief.narrative_angle}</span>
+          </div>
+        )}
+
+        {brief.script && (
+          <p className="text-sm text-muted-foreground line-clamp-3">
+            {brief.script}
+          </p>
+        )}
+
+        {brief.target_emotion && (
+          <div>
+            <span className="text-sm font-bold">Emotion: </span>
+            <span className="text-sm">{brief.target_emotion}</span>
+          </div>
+        )}
+
+        {brief.cta_text && (
+          <div>
+            <span className="text-sm font-bold">CTA: </span>
+            <span className="text-sm">{brief.cta_text}</span>
+          </div>
+        )}
+
+        {sceneSummary && (
+          <p className="text-sm text-muted-foreground">{sceneSummary}</p>
+        )}
+      </CardContent>
+
+      <CardFooter className="justify-between">
+        <span className="text-xs text-muted-foreground">
+          {brief.target_format} &middot; {brief.target_duration}s
+        </span>
+        <div className="flex gap-2">
+          {brief.status === "draft" && (
+            <Button size="sm" onClick={onApprove}>
+              <Check className="mr-1 h-4 w-4" />
+              Approve
+            </Button>
+          )}
+          <Button size="sm" variant="ghost" onClick={onDelete} className="text-destructive">
+            <Trash2 className="mr-1 h-4 w-4" />
+            Delete
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/packages/web/components/brief-card.tsx
+++ b/packages/web/components/brief-card.tsx
@@ -15,6 +15,10 @@ interface Scene {
   [key: string]: unknown;
 }
 
+function isScene(value: unknown): value is Scene {
+  return typeof value === "object" && value !== null && typeof (value as Scene).strategy === "string";
+}
+
 function getStrategyBreakdown(scenes: Scene[]): string {
   const counts: Record<string, number> = {};
   for (const scene of scenes) {
@@ -27,8 +31,10 @@ function getStrategyBreakdown(scenes: Scene[]): string {
 
 function getScenePlanSummary(scenePlan: Record<string, unknown> | null): string | null {
   if (!scenePlan) return null;
-  const scenes = scenePlan.scenes as Scene[] | undefined;
-  if (!Array.isArray(scenes) || scenes.length === 0) return null;
+  const raw = scenePlan.scenes;
+  if (!Array.isArray(raw)) return null;
+  const scenes = raw.filter(isScene);
+  if (scenes.length === 0) return null;
   const breakdown = getStrategyBreakdown(scenes);
   return `${scenes.length} scenes: ${breakdown}`;
 }

--- a/packages/web/components/concept-review.tsx
+++ b/packages/web/components/concept-review.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Sparkles } from "lucide-react";
+import { BriefCard } from "@/components/brief-card";
+import { useBriefs, useGenerateConcepts, useUpdateBrief, useDeleteBrief } from "@/lib/hooks/use-briefs";
+import type { Brief, BriefStatus } from "@/lib/types/brief";
+
+const STATUS_FILTERS: { label: string; value: BriefStatus | undefined }[] = [
+  { label: "All", value: undefined },
+  { label: "Draft", value: "draft" },
+  { label: "Approved", value: "approved" },
+];
+
+interface ConceptReviewProps {
+  projectId: string;
+}
+
+export function ConceptReview({ projectId }: ConceptReviewProps) {
+  const [statusFilter, setStatusFilter] = useState<BriefStatus | undefined>(undefined);
+  const { data: briefs, isLoading, isError } = useBriefs(projectId, statusFilter);
+  const generateConcepts = useGenerateConcepts(projectId);
+  const deleteBrief = useDeleteBrief();
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>Creative Concepts</CardTitle>
+          <Button
+            onClick={() => generateConcepts.mutate()}
+            disabled={generateConcepts.isPending}
+          >
+            <Sparkles className="mr-2 h-4 w-4" />
+            {generateConcepts.isPending ? "Generating..." : "Generate Concepts"}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Status filter buttons */}
+        <div className="flex gap-2">
+          {STATUS_FILTERS.map((filter) => (
+            <Badge
+              key={filter.label}
+              variant={statusFilter === filter.value ? "default" : "secondary"}
+              className="cursor-pointer"
+              onClick={() => setStatusFilter(filter.value)}
+            >
+              {filter.label}
+            </Badge>
+          ))}
+        </div>
+
+        {/* Content */}
+        {isLoading && (
+          <p className="text-sm text-muted-foreground">Loading concepts...</p>
+        )}
+
+        {isError && (
+          <p className="text-sm text-destructive">Failed to load concepts.</p>
+        )}
+
+        {!isLoading && !isError && briefs && briefs.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No concepts yet. Generate concepts from your game profile.
+          </p>
+        )}
+
+        {briefs && briefs.length > 0 && (
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {briefs.map((brief) => (
+              <BriefCardWrapper
+                key={brief.id}
+                brief={brief}
+                onDelete={() => deleteBrief.mutate(brief.id)}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// Wrapper to scope useUpdateBrief to each brief
+function BriefCardWrapper({ brief, onDelete }: { brief: Brief; onDelete: () => void }) {
+  const updateBrief = useUpdateBrief(brief.id);
+  return (
+    <BriefCard
+      brief={brief}
+      onApprove={() => updateBrief.mutate({ status: "approved" })}
+      onDelete={onDelete}
+    />
+  );
+}

--- a/packages/web/components/concept-review.tsx
+++ b/packages/web/components/concept-review.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Sparkles } from "lucide-react";
 import { BriefCard } from "@/components/brief-card";
 import { useBriefs, useGenerateConcepts, useUpdateBrief, useDeleteBrief } from "@/lib/hooks/use-briefs";
@@ -40,17 +39,18 @@ export function ConceptReview({ projectId }: ConceptReviewProps) {
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        {/* Status filter buttons */}
-        <div className="flex gap-2">
+        <div className="flex gap-2" role="tablist" aria-label="Concept status filters">
           {STATUS_FILTERS.map((filter) => (
-            <Badge
+            <Button
               key={filter.label}
               variant={statusFilter === filter.value ? "default" : "secondary"}
-              className="cursor-pointer"
+              size="sm"
+              role="tab"
+              aria-selected={statusFilter === filter.value}
               onClick={() => setStatusFilter(filter.value)}
             >
               {filter.label}
-            </Badge>
+            </Button>
           ))}
         </div>
 

--- a/packages/web/lib/api/briefs.ts
+++ b/packages/web/lib/api/briefs.ts
@@ -1,0 +1,33 @@
+import type { Brief, BriefStatus, BriefUpdate } from "@/lib/types/brief";
+import { apiGet, apiPost, apiPatch, apiDelete } from "./client";
+
+export async function generateConcepts(projectId: string): Promise<Brief[]> {
+  return apiPost<Brief[]>(`/api/projects/${projectId}/concepts`, {});
+}
+
+export async function listBriefs(
+  projectId: string,
+  status?: BriefStatus,
+): Promise<Brief[]> {
+  const params = new URLSearchParams();
+  if (status) params.set("status", status);
+  const query = params.toString();
+  return apiGet<Brief[]>(
+    `/api/projects/${projectId}/briefs${query ? `?${query}` : ""}`,
+  );
+}
+
+export async function getBrief(briefId: string): Promise<Brief> {
+  return apiGet<Brief>(`/api/briefs/${briefId}`);
+}
+
+export async function updateBrief(
+  briefId: string,
+  data: BriefUpdate,
+): Promise<Brief> {
+  return apiPatch<Brief>(`/api/briefs/${briefId}`, data);
+}
+
+export async function deleteBrief(briefId: string): Promise<void> {
+  return apiDelete(`/api/briefs/${briefId}`);
+}

--- a/packages/web/lib/hooks/use-briefs.ts
+++ b/packages/web/lib/hooks/use-briefs.ts
@@ -1,0 +1,41 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { listBriefs, generateConcepts, updateBrief, deleteBrief } from "@/lib/api/briefs";
+import type { BriefStatus, BriefUpdate } from "@/lib/types/brief";
+
+export function useBriefs(projectId: string, status?: BriefStatus) {
+  return useQuery({
+    queryKey: ["briefs", "list", projectId, status],
+    queryFn: () => listBriefs(projectId, status),
+    enabled: !!projectId,
+  });
+}
+
+export function useGenerateConcepts(projectId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => generateConcepts(projectId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["briefs"] });
+    },
+  });
+}
+
+export function useUpdateBrief(briefId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: BriefUpdate) => updateBrief(briefId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["briefs"] });
+    },
+  });
+}
+
+export function useDeleteBrief() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (briefId: string) => deleteBrief(briefId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["briefs"] });
+    },
+  });
+}

--- a/packages/web/lib/types/brief.ts
+++ b/packages/web/lib/types/brief.ts
@@ -1,0 +1,33 @@
+export type BriefStatus = "draft" | "approved" | "producing" | "complete";
+
+export interface Brief {
+  id: string;
+  project_id: string;
+  hook_type: string | null;
+  narrative_angle: string | null;
+  script: string | null;
+  voiceover_text: string | null;
+  target_emotion: string | null;
+  cta_text: string | null;
+  reference_ads: string[];
+  target_format: string;
+  target_duration: number;
+  status: BriefStatus;
+  generated_by: string;
+  scene_plan: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface BriefUpdate {
+  hook_type?: string | null;
+  narrative_angle?: string | null;
+  script?: string | null;
+  voiceover_text?: string | null;
+  target_emotion?: string | null;
+  cta_text?: string | null;
+  status?: BriefStatus;
+  scene_plan?: Record<string, unknown> | null;
+  target_format?: string;
+  target_duration?: number;
+}


### PR DESCRIPTION
## Summary
- Added concept review section to the project detail page for browsing and managing AI-generated creative briefs
- "Generate Concepts" button triggers the AI concept agent pipeline to create briefs from the game profile
- Each brief displayed as a card with hook type, narrative angle, script, scene plan summary, and status
- Users can approve draft briefs, delete briefs, and filter by status (All/Draft/Approved)

## Changes

**New files (8):**
- `lib/types/brief.ts` — TypeScript types (Brief, BriefStatus, BriefUpdate)
- `lib/api/briefs.ts` — API client (generateConcepts, listBriefs, getBrief, updateBrief, deleteBrief)
- `lib/hooks/use-briefs.ts` — React Query hooks (useBriefs, useGenerateConcepts, useUpdateBrief, useDeleteBrief)
- `components/brief-card.tsx` — Brief display card with hook type, script, scene plan summary, approve/delete actions
- `components/concept-review.tsx` — Section composing generation button, status filters, and brief cards grid
- `__tests__/unit/api-briefs.test.ts` — 6 tests for API client
- `__tests__/unit/use-briefs.test.tsx` — 5 tests for hooks
- `__tests__/unit/brief-card.test.tsx` — 7 tests for BriefCard
- `__tests__/unit/concept-review.test.tsx` — 4 tests for ConceptReview

**Modified files (1):**
- `app/projects/[id]/page.tsx` — Added ConceptReview section below AssetUpload

## Testing
- 22 new tests (95 total, all passing)
- API client: concept generation trigger, brief CRUD
- Hooks: query/mutation flows including status filtering
- Components: card rendering, approve/delete actions, status filters, empty states
- Manual: navigate to `/projects/[id]`, click "Generate Concepts", approve/delete briefs, filter by status

## Notes
- Scene plan is displayed read-only as a summary (e.g., "3 scenes: 1 GENERATE, 1 COMPOSE, 1 RENDER")
- Brief editing (inline field changes) is deferred — this PR covers approve/delete workflows
- `BriefCardWrapper` scopes `useUpdateBrief` per brief ID to avoid hook rules violations

---
Generated with [Agent Harness](https://github.com/Alchemishty/agent-harness)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Creative Concepts" section to the project detail page, allowing users to generate AI-powered creative briefs.
  * Users can now view, approve, or delete generated concepts with status filtering options (All, Draft, Approved).
  * Displays detailed concept information including hook type, script preview, scene plan summary, and approval status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->