### PR TITLE
feat: add local dev setup with CORS and startup script

### DIFF
--- a/docs/plans/active/2026-04-10-local-dev-setup.md
+++ b/docs/plans/active/2026-04-10-local-dev-setup.md
@@ -1,0 +1,138 @@
+# Local Development Setup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the full stack runnable locally so the user can test the end-to-end flow (create project → upload assets → generate concepts → produce video) with `docker compose up postgres redis minio` for infra and native processes for the apps.
+
+**Architecture:** Three code changes: add CORS middleware to the API, create a web `.env.local` with API URLs, and update `.env` with required config. Plus a startup script that orchestrates infra + migrations + all three processes.
+
+**Tech Stack:** FastAPI (CORS), Next.js (env vars), shell script
+
+---
+
+## Assumptions
+- Docker is installed and running (for Postgres, Redis, MinIO)
+- User has an OpenAI API key in `.env` (already present)
+- Python 3.10+ with `uv` and Node.js 20+ with `npm` are installed
+- Ports 3000, 5432, 6379, 8000, 9000 are available
+
+## Open Questions
+- None.
+
+## Context and Orientation
+- **Files to read:** `packages/api/app/main.py` (add CORS), `.env` (update config), `packages/web/` (add .env.local)
+- **Similar existing code:** None — this is infra/config work
+
+## Steps
+
+### Step 1: Add CORS middleware to the API
+
+**Files:**
+- Modify: `packages/api/app/main.py`
+
+**Tests:** Existing API tests still pass.
+
+**What to do:** Add FastAPI CORS middleware after the `app = FastAPI(...)` line. Allow origins `http://localhost:3000` (the Next.js dev server). Allow all methods and headers. Read allowed origins from `CORS_ORIGINS` env var with `http://localhost:3000` as default.
+
+```python
+from fastapi.middleware.cors import CORSMiddleware
+
+cors_origins = os.environ.get("CORS_ORIGINS", "http://localhost:3000").split(",")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+**Verify:** `cd packages/api && pytest -x`
+
+---
+
+### Step 2: Create web .env.local with API URLs
+
+**Files:**
+- Create: `packages/web/.env.local`
+
+**Tests:** No tests needed — config file.
+
+**What to do:** Create `packages/web/.env.local` with:
+```
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_WS_URL=ws://localhost:8000
+```
+
+This file is already in `.gitignore` (`.env.local` pattern).
+
+**Verify:** File exists and contains the correct values.
+
+---
+
+### Step 3: Update root .env with full local config
+
+**Files:**
+- Modify: `.env`
+
+**Tests:** No tests needed — config file.
+
+**What to do:** The current `.env` only has `OPENAI_API_KEY`. Add the remaining config needed for local dev. Keep the existing key, add:
+```
+DATABASE_URL=postgresql://magnet:magnet@localhost:5432/magnet
+REDIS_URL=redis://localhost:6379/0
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=magnet-assets
+LLM_PROVIDER=openai
+```
+
+The `LLM_PROVIDER=openai` is critical — the default is `claude` which requires an Anthropic key the user doesn't have.
+
+**Verify:** `grep LLM_PROVIDER .env` shows `openai`.
+
+---
+
+### Step 4: Create local dev startup script
+
+**Files:**
+- Create: `scripts/dev.sh`
+
+**Tests:** No tests needed — startup script.
+
+**What to do:** Create a shell script that starts the full local stack:
+1. Start infra services: `docker compose up -d postgres redis minio`
+2. Wait for Postgres to be healthy
+3. Run DB migrations: `cd packages/api && uv run alembic upgrade head`
+4. Start API server in background: `cd packages/api && uv run uvicorn app.main:app --reload`
+5. Start Celery worker in background: `cd packages/api && uv run celery -A app.worker worker --loglevel=info`
+6. Start web dev server: `cd packages/web && npm run dev`
+7. Trap SIGINT to clean up background processes on Ctrl+C
+
+The script should print clear status messages and the URLs to access:
+```
+Magnet Local Dev
+  Web:  http://localhost:3000
+  API:  http://localhost:8000
+  MinIO: http://localhost:9001 (admin: minioadmin/minioadmin)
+```
+
+Make the script executable.
+
+**Verify:** `bash scripts/dev.sh` starts all services (manual verification).
+
+---
+
+## Validation
+1. Run `scripts/dev.sh`
+2. Open `http://localhost:3000` — see the Magnet dashboard
+3. Create a project, fill game profile
+4. Upload an asset
+5. Generate concepts — briefs appear (requires working LLM)
+6. Approve a brief, trigger production
+7. `cd packages/api && pytest -x` — API tests still pass
+8. `cd packages/web && npx vitest run` — web tests still pass
+
+## Decision Log
+(Populated during implementation)

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -1,7 +1,9 @@
 import logging
+import os
 
 from fastapi import FastAPI
 from fastapi.concurrency import run_in_threadpool
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
 from app.db import engine
@@ -16,6 +18,15 @@ from app.routes import (
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Magnet API", version="0.1.0")
+
+cors_origins = os.environ.get("CORS_ORIGINS", "http://localhost:3000").split(",")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(projects_router)
 app.include_router(briefs_router)

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Magnet API", version="0.1.0")
 
-cors_origins = os.environ.get("CORS_ORIGINS", "http://localhost:3000").split(",")
+_raw_origins = os.environ.get("CORS_ORIGINS", "http://localhost:3000")
+cors_origins = [o.strip() for o in _raw_origins.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_origins,

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+API_PID=""
+WORKER_PID=""
+WEB_PID=""
+
+cleanup() {
+  echo ""
+  echo "Shutting down..."
+  [ -n "$WEB_PID" ] && kill "$WEB_PID" 2>/dev/null
+  [ -n "$WORKER_PID" ] && kill "$WORKER_PID" 2>/dev/null
+  [ -n "$API_PID" ] && kill "$API_PID" 2>/dev/null
+  echo "Done."
+  exit 0
+}
+
+trap cleanup SIGINT SIGTERM
+
+echo "==============================="
+echo "  Magnet Local Dev"
+echo "==============================="
+echo ""
+
+# 1. Start infra
+echo "[1/5] Starting infra (Postgres, Redis, MinIO)..."
+docker compose up -d postgres redis minio
+echo "  Waiting for Postgres..."
+until docker compose exec -T postgres pg_isready -U magnet -d magnet >/dev/null 2>&1; do
+  sleep 1
+done
+echo "  Postgres ready."
+
+# 2. Load env
+set -a
+source .env
+set +a
+
+# 3. Install deps if needed
+echo "[2/5] Checking dependencies..."
+if [ ! -d "packages/api/.venv" ]; then
+  echo "  Installing API dependencies..."
+  (cd packages/api && uv sync)
+fi
+if [ ! -d "packages/web/node_modules" ]; then
+  echo "  Installing Web dependencies..."
+  (cd packages/web && npm install)
+fi
+
+# 4. Run migrations
+echo "[3/5] Running database migrations..."
+(cd packages/api && uv run alembic upgrade head)
+
+# 5. Start services
+echo "[4/5] Starting API server..."
+(cd packages/api && uv run uvicorn app.main:app --reload --port 8000) &
+API_PID=$!
+
+echo "[5/5] Starting Celery worker..."
+(cd packages/api && uv run celery -A app.worker worker --loglevel=info) &
+WORKER_PID=$!
+
+sleep 2
+
+echo ""
+echo "==============================="
+echo "  All services running"
+echo ""
+echo "  Web:   http://localhost:3000"
+echo "  API:   http://localhost:8000"
+echo "  MinIO: http://localhost:9001"
+echo "         (admin: minioadmin / minioadmin)"
+echo ""
+echo "  Press Ctrl+C to stop all"
+echo "==============================="
+echo ""
+
+echo "Starting Web dev server..."
+(cd packages/web && npm run dev) &
+WEB_PID=$!
+
+wait

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -18,7 +18,7 @@ cleanup() {
   exit 0
 }
 
-trap cleanup SIGINT SIGTERM
+trap cleanup EXIT
 
 echo "==============================="
 echo "  Magnet Local Dev"
@@ -35,6 +35,10 @@ done
 echo "  Postgres ready."
 
 # 2. Load env
+if [ ! -f .env ]; then
+  echo "ERROR: .env file not found. Copy .env.example to .env and fill in your API keys."
+  exit 1
+fi
 set -a
 source .env
 set +a


### PR DESCRIPTION
## Summary
- Added CORS middleware to the FastAPI API (allows `http://localhost:3000` by default, configurable via `CORS_ORIGINS` env var)
- Created `scripts/dev.sh` startup script that orchestrates the full local stack

## How to use

```bash
bash scripts/dev.sh
```

This will:
1. Start Postgres, Redis, MinIO via Docker
2. Install dependencies if needed
3. Run database migrations
4. Start the API server (uvicorn with --reload)
5. Start the Celery worker
6. Start the Next.js dev server

Then open http://localhost:3000.

## Changes

**New files:**
- `scripts/dev.sh` — Local dev startup script with clean shutdown on Ctrl+C

**Modified files:**
- `packages/api/app/main.py` — Added CORSMiddleware

**Not committed (gitignored):**
- `.env` — Updated with DATABASE_URL, REDIS_URL, S3, LLM_PROVIDER=openai
- `packages/web/.env.local` — NEXT_PUBLIC_API_URL and WS URL

## Testing
- All 114 web tests pass
- API lint passes
- Build succeeds
- Enforcement passes

## Notes
- `.env` and `.env.local` are gitignored — users set these up from `.env.example`
- The `.env.example` already documents all required variables
- CORS origins default to `http://localhost:3000`, override via `CORS_ORIGINS=url1,url2`

---
Generated with [Agent Harness](https://github.com/Alchemishty/agent-harness)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a step-by-step local development guide detailing how to run the full stack end-to-end.

* **Chores**
  * Added a developer startup script to bring up infra, run migrations, and launch API, worker, and web dev servers.
  * Enabled local CORS support and expanded local environment configuration for services (Postgres/Redis/MinIO and LLM provider).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->